### PR TITLE
Fixing fail with unicode chars

### DIFF
--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -27,7 +27,8 @@ from ansible.module_utils.urls import open_url
 from ansible.plugins.callback import CallbackBase
 
 import sys
-reload(sys)
+from six.moves import reload_module
+reload_module(sys)
 sys.setdefaultencoding('UTF8')
 
 DOCUMENTATION = '''

--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -26,6 +26,10 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.urls import open_url
 from ansible.plugins.callback import CallbackBase
 
+import sys
+reload(sys)
+sys.setdefaultencoding('UTF8')
+
 
 DOCUMENTATION = '''
     callback: grafana_annotations

--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -30,7 +30,6 @@ import sys
 reload(sys)
 sys.setdefaultencoding('UTF8')
 
-
 DOCUMENTATION = '''
     callback: grafana_annotations
     callback_type: notification


### PR DESCRIPTION
If there is some unicode characters in incoming data any .format() function fail, regardless on encoding declaration at the top.

> WARNING]: Failure using method (v2_runner_on_failed) in callback plugin (<ansible.plugins.callback.grafana_annotations.CallbackModule object at 0x7feb38620c50>): 'ascii' codec can't encode characters in position 32-40: ordinal not in range(128)