### PR TITLE
Test Grafana 7.x

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        grafana_version: ["6.5.3", "6.6.2", "6.7.3"]
+        grafana_version: ["6.5.3", "6.6.2", "6.7.3", "7.0.0"]
         python_version: ["3.6"]
     container:
       image: python:${{ matrix.python_version }}-alpine

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Click on the name of a plugin or module to view that content's documentation:
 
 ## Supported Grafana versions
 
-This collection is currently testing the modules against Grafana versions `6.4.5`, `6.5.3`, `6.6.2`.
-We aim at keeping the last 3 minor versions of Grafana tested.
+We aim at keeping the last 3 minor versions (at least) of Grafana tested.
+This collection is currently testing the modules against Grafana versions `6.5.3`, `6.6.2`, `6.7.3` and even `7.0.0`.
 
 ## Installation and Usage
 


### PR DESCRIPTION
##### SUMMARY

Grafana v7 was released, let's see what is now broken in the collection 🥳 
