### PR TITLE
support elasticsearch version 6.0+, 7.0+

### DIFF
--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -131,6 +131,8 @@ options:
     - 2
     - 5
     - 56
+    - 60
+    - 70
     default: 5
     type: int
   max_concurrent_shard_requests:
@@ -579,7 +581,7 @@ def main():
         tls_skip_verify=dict(type='bool', default=False),
         is_default=dict(default=False, type='bool'),
         org_id=dict(default=1, type='int'),
-        es_version=dict(type='int', default=5, choices=[2, 5, 56]),
+        es_version=dict(type='int', default=5, choices=[2, 5, 56, 60, 70]),
         max_concurrent_shard_requests=dict(type='int', default=256),
         time_field=dict(default='@timestamp', type='str'),
         time_interval=dict(type='str'),
@@ -614,7 +616,9 @@ def main():
             ['ds_type', 'mysql', ['database']],
             ['ds_type', 'postgres', ['database', 'sslmode']],
             ['ds_type', 'cloudwatch', ['aws_auth_type', 'aws_default_region']],
-            ['es_version', 56, ['max_concurrent_shard_requests']]
+            ['es_version', 56, ['max_concurrent_shard_requests']],
+            ['es_version', 60, ['max_concurrent_shard_requests']],
+            ['es_version', 70, ['max_concurrent_shard_requests']]
         ],
     )
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,0 +1,2 @@
+plugins/modules/grafana_dashboard.py validate-modules:invalid-argument-name
+tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py pep8:W291


### PR DESCRIPTION
##### SUMMARY
You are able to select es version 6.0+ and 7.0+ in the grafana GUI.
This change will support this via the ansible module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_datasource



