### PR TITLE
adding additional_secure_json_data

### DIFF
--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 module: grafana_dashboard
 author:
   - Thierry Sallé (@seuf)
-version_added: "2.5"
+version_added: "1.0.0"
 short_description: Manage Grafana dashboards
 description:
   - Create, update, delete, export Grafana dashboards via API.
@@ -26,7 +26,7 @@ options:
     description:
       - The Grafana folder where this dashboard will be imported to.
     default: General
-    version_added: '2.10.0'
+    version_added: "1.0.0"
     type: str
   state:
     description:
@@ -43,7 +43,7 @@ options:
         you have to specify the slug parameter because there is no meta section in the exported json.
     type: str
   uid:
-    version_added: '2.7.0'
+    version_added: "1.0.0"
     description:
       - uid of the dashboard to export when C(state) is C(export) or C(absent).
     type: str
@@ -62,13 +62,13 @@ options:
   dashboard_id:
     description:
       - Public Grafana.com dashboard id to import
-    version_added: '2.10.0'
+    version_added: "1.0.0"
     type: str
   dashboard_revision:
     description:
       - Revision of the public grafana dashboard to import
     default: 1
-    version_added: '2.10.0'
+    version_added: "1.0.0"
     type: str
   commit_message:
     description:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -65,13 +65,11 @@ options:
   password:
     description:
     - The datasource password.
-    - Unencrypted! For secure save use additional_secure_json_data.
     type: str
   secure_password:
     description:
-    - Sets the secureJsonData.password field
+    - must be supported by datasource
     - stored in secureJsonData (see notes!)
-    - Datasource has to support secureJsonData.password!
     type: str
   basic_auth_user:
     description:
@@ -256,7 +254,6 @@ options:
   aws_secret_key:
     description:
     - AWS secret key for CloudWatch datasource type when C(aws_auth_type) is C(keys)
-    - stored in secureJsonData (see notes!)
     default: ''
     required: false
     type: str
@@ -300,7 +297,7 @@ options:
     default: {}
   dontReportSecureDataChanges:
     description:
-    - reports a task as `changed=false` even if `secureJsonData` has changed
+    - reports a task as changed=false even if secureJsonData has changed
     - implemented for backward compatibility reasons, will get deprecated by next releases
     required: false
     type: bool
@@ -308,12 +305,11 @@ options:
 extends_documentation_fragment:
 - community.grafana.basic_auth
 - community.grafana.api_key
-
 notes:
-- secureJsonData/secureJsonFields related things:
--- secureJsonData is converted to encrypted data by Grafana API and shown as secureJsonFields in requests
--- secureJsonFields shows `true` for all fields set
--- As the data is encrypted it can not be compared on subsequent runs, thus each run reports `changed=true` for the task
+- secureJsonData is converted to encrypted data by Grafana API and shown as secureJsonFields in requests.
+- secureJsonFields shows boolean true for all fields set.
+- As the secureJsonData is encrypted it can not be compared on subsequent runs, thus each run reports `changed=true` for
+  the task. See dontReportSecureDataChanges property.
 '''
 
 EXAMPLES = '''
@@ -446,7 +442,7 @@ def compare_datasources(new, current, ignoreSecureJsonData=True):
 
     # check if secureJsonData should be ignored
     if ignoreSecureJsonData:
-        #if so just drop alltogether
+        # if so just drop alltogether
         new.pop('secureJsonData', None)
         new.pop('secureJsonFields', None)
         current.pop('secureJsonData', None)

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -312,7 +312,7 @@ extends_documentation_fragment:
 notes:
 - Secure data will get encrypted by the Grafana API, thus it can not be compared on subsequent runs. To workaround this, secure
   data will not be updated after initial creation! To force the secure data update you have to set I(enforce_secure_data=True).
-- Hint, with the C(enforce_secure_data) always reporting changed=True, you might just do one Task updateing the datasource without
+- Hint, with the C(enforce_secure_data) always reporting changed=True, you might just do one Task updating the datasource without
   any secure data and make a separate playbook/task with changing also the secure data. This way it wont break any workflow.
 '''
 

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -448,12 +448,12 @@ def compare_datasources(new, current):
     # - secureJsonFields is reporting each field set as true
     # - secureJsonFields once set cant be removed (DS has to be deleted)
     if not new.get('secureJsonData'):
-      # secureJsonData is not provided so just remove booth for comparision
-      new.pop('secureJsonData', None)
-      current.pop('secureJsonFields', None)
+        # secureJsonData is not provided so just remove booth for comparision
+        new.pop('secureJsonData', None)
+        current.pop('secureJsonFields', None)
     else:
-      # we have some secure data so just "rename" secureJsonFields for comparison as it will change anyhow everytime
-      current['secureJsonData'] = current.pop('secureJsonFields')
+        # we have some secure data so just "rename" secureJsonFields for comparison as it will change anyhow everytime
+        current['secureJsonData'] = current.pop('secureJsonFields')
 
     return dict(before=current, after=new)
 
@@ -547,9 +547,9 @@ def get_datasource_payload(data):
         if data.get('aws_access_key') and data.get('aws_secret_key'):
             secure_json_data['accessKey'] = data.get('aws_access_key')
             secure_json_data['secretKey'] = data.get('aws_secret_key')
-    
+
     if data.get('secure_password'):
-      secure_json_data['password'] = data.get('secure_password')
+        secure_json_data['password'] = data.get('secure_password')
 
     payload['jsonData'] = json_data
     payload['secureJsonData'] = secure_json_data
@@ -712,13 +712,13 @@ def main():
             # check if backward compatibilty is enabled
             # if so remove not compareable datasets
             if module.params.get('dontReportSecureDataChanges'):
-              diff = compare_datasources(payload.copy(), ds.copy())
-              diff['before'].pop('secureJsonData', None)
-              diff['before'].pop('secureJsonFields', None)
-              diff['after'].pop('secureJsonData', None)
-              diff['after'].pop('secureJsonFields', None)
-              if diff.get('before') == diff.get('after'):
-                module.exit_json(changed=False, datasource=ds, msg='Datasource %s unchanged (secureJson ignored!)' % name)
+                diff = compare_datasources(payload.copy(), ds.copy())
+                diff['before'].pop('secureJsonData', None)
+                diff['before'].pop('secureJsonFields', None)
+                diff['after'].pop('secureJsonData', None)
+                diff['after'].pop('secureJsonFields', None)
+                if diff.get('before') == diff.get('after'):
+                    module.exit_json(changed=False, datasource=ds, msg='Datasource %s unchanged (secureJson ignored!)' % name)
 
             module.exit_json(changed=True, diff=diff, datasource=ds, msg='Datasource %s updated' % name)
     else:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -504,7 +504,7 @@ def get_datasource_payload(data):
         json_data['password'] = data['zabbix_password']
 
     if data['ds_type'] == 'cloudwatch':
-        if data.get('aws_credentials_profle'):
+        if data.get('aws_credentials_profile'):
             payload['database'] = data.get('aws_credentials_profile')
 
         json_data['authType'] = data['aws_auth_type']

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -36,6 +36,7 @@ options:
     - cloudwatch
     - alexanderzobnin-zabbix-datasource
     - sni-thruk-datasource
+    - camptocamp-prometheus-alertmanager-datasource
     - loki
     type: str
   ds_url:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -311,7 +311,7 @@ extends_documentation_fragment:
 - community.grafana.api_key
 notes:
 - Secure data will get encrypted by the Grafana API, thus it can not be compared on subsequent runs. To workaround this, secure
-  data will not be updated after initial creation! To update also secure data you have to set I(enforce_secure_data=True).
+  data will not be updated after initial creation! To force the secure data update you have to set I(enforce_secure_data=True).
 - Hint, with the C(enforce_secure_data) always reporting changed=True, you might just do one Task updateing the datasource without
   any secure data and make a separate playbook/task with changing also the secure data. This way it wont break any workflow.
 '''

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -301,7 +301,7 @@ options:
     - implemented for backward compatibility reasons, will get deprecated by next releases
     required: false
     type: bool
-    default: true
+    default: false
 extends_documentation_fragment:
 - community.grafana.basic_auth
 - community.grafana.api_key
@@ -631,6 +631,7 @@ def main():
                               'postgres',
                               'cloudwatch',
                               'alexanderzobnin-zabbix-datasource',
+                              'camptocamp-prometheus-alertmanager-datasource',
                               'sni-thruk-datasource',
                               'loki'], required=True),
         ds_url=dict(required=True, type='str'),
@@ -673,7 +674,7 @@ def main():
         zabbix_password=dict(type='str', no_log=True),
         additional_json_data=dict(type='dict', default={}, required=False),
         additional_secure_json_data=dict(type='dict', default={}, required=False),
-        dontReportSecureDataChanges=dict(type='bool', default=True, required=False)
+        dontReportSecureDataChanges=dict(type='bool', default=False, required=False)
     )
 
     module = AnsibleModule(

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -483,7 +483,7 @@ def compare_datasources(new, current, compareSecureData=True):
         # - secureJsonFields is reporting each field set as true
         # - secureJsonFields once set cant be removed (DS has to be deleted)
         if not new.get('secureJsonData'):
-            # secureJsonData is not provided so just remove booth for comparision
+            # secureJsonData is not provided so just remove both for comparision
             new.pop('secureJsonData', None)
             current.pop('secureJsonFields', None)
         else:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -313,7 +313,7 @@ notes:
 - Secure data will get encrypted by the Grafana API, thus it can not be compared on subsequent runs. To workaround this, secure
   data will not be updated after initial creation! To force the secure data update you have to set I(enforce_secure_data=True).
 - Hint, with the C(enforce_secure_data) always reporting changed=True, you might just do one Task updating the datasource without
-  any secure data and make a separate playbook/task with changing also the secure data. This way it wont break any workflow.
+  any secure data and make a separate playbook/task also changing the secure data. This way it will not break any workflow.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/grafana_folder.py
+++ b/plugins/modules/grafana_folder.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
 module: grafana_folder
 author:
   - Rémi REY (@rrey)
-version_added: "2.10"
+version_added: "1.0.0"
 short_description: Manage Grafana Folders
 description:
   - Create/update/delete Grafana Folders through the Folders API.

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
 module: grafana_team
 author:
   - Rémi REY (@rrey)
-version_added: "2.10"
+version_added: "1.0.0"
 short_description: Manage Grafana Teams
 description:
   - Create/update/delete Grafana Teams through the Teams API.

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -27,7 +27,7 @@ author:
   - Hong Viet LE (@pomverte)
   - Julien Alexandre (@jual)
   - Marc Cyprien (@LeFameux)
-version_added: "2.10"
+version_added: "1.0.0"
 short_description: Manage Grafana User
 description:
   - Create/update/delete Grafana User through the users and admin API.

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -153,7 +153,7 @@
         es_version: 56
         max_concurrent_shard_requests: 42
         tls_ca_cert: /etc/ssl/certs/ca.pem
-        dontReportSecureDataChanges: true
+        enforce_secure_data: false
         additional_json_data:
           nonSecureTest: "nonsecure"
         additional_secure_json_data:
@@ -184,7 +184,7 @@
         - result.datasource.user == ''
         - not result.datasource.withCredentials
         - result.datasource.jsonData.nonSecureTest == 'nonsecure'
-        - result.datasource.secureJsonFields.secureTest == true
+        - result.datasource.secureJsonFields is not defined
         - result.diff.after.secureJsonData is not defined
 
     - name: update elasticsearch datasource (including secureJsonData)
@@ -206,7 +206,7 @@
         es_version: 56
         max_concurrent_shard_requests: 42
         tls_ca_cert: /etc/ssl/certs/ca.pem
-        dontReportSecureDataChanges: false
+        enforce_secure_data: true
         additional_json_data:
           nonSecureTest: "nonsecure"
         additional_secure_json_data:

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -134,6 +134,112 @@
     - result.datasource.user == ''
     - not result.datasource.withCredentials
 
+    - name: update elasticsearch datasource (ignoring secureJsonData)
+      register: result
+      grafana_datasource:
+        name: datasource-elastic
+        grafana_url: "{{ grafana_url }}"
+        grafana_user: "{{ grafana_username }}"
+        grafana_password: "{{ grafana_password }}"
+        org_id: '1'
+        ds_type: elasticsearch
+        ds_url: https://elastic.example.com:9200
+        database: '[logstash_]YYYY.MM.DD'
+        basic_auth_user: grafana
+        basic_auth_password: '******'
+        time_field: '@timestamp'
+        time_interval: 1m
+        interval: Daily
+        es_version: 56
+        max_concurrent_shard_requests: 42
+        tls_ca_cert: /etc/ssl/certs/ca.pem
+        dontReportSecureDataChanges: true
+        additional_json_data:
+          nonSecureTest: "nonsecure"
+        additional_secure_json_data:
+          secureTest: "secure"
+
+    - debug:
+        var: result
+
+    - assert:
+        that:
+        - result.changed
+        - result.datasource.basicAuth
+        - result.datasource.basicAuthUser == 'grafana'
+        - result.datasource.access == 'proxy'
+        - result.datasource.database == '[logstash_]YYYY.MM.DD'
+        - not result.datasource.isDefault
+        - result.datasource.jsonData.esVersion == 56
+        - result.datasource.jsonData.interval == 'Daily'
+        - result.datasource.jsonData.maxConcurrentShardRequests == 42
+        - result.datasource.jsonData.timeField == '@timestamp'
+        - not result.datasource.jsonData.tlsAuth
+        - not result.datasource.jsonData.tlsAuthWithCACert
+        - result.datasource.name == 'datasource-elastic'
+        - result.datasource.orgId == 1
+        - result.datasource.password == ''
+        - result.datasource.type == 'elasticsearch'
+        - result.datasource.url == 'https://elastic.example.com:9200'
+        - result.datasource.user == ''
+        - not result.datasource.withCredentials
+        - result.datasource.jsonData.nonSecureTest == 'nonsecure'
+        - result.datasource.secureJsonFields.secureTest == true
+        - result.diff.after.secureJsonData is not defined
+
+    - name: update elasticsearch datasource (including secureJsonData)
+      register: result
+      grafana_datasource:
+        name: datasource-elastic
+        grafana_url: "{{ grafana_url }}"
+        grafana_user: "{{ grafana_username }}"
+        grafana_password: "{{ grafana_password }}"
+        org_id: '1'
+        ds_type: elasticsearch
+        ds_url: https://elastic.example.com:9200
+        database: '[logstash_]YYYY.MM.DD'
+        basic_auth_user: grafana
+        basic_auth_password: '******'
+        time_field: '@timestamp'
+        time_interval: 1m
+        interval: Daily
+        es_version: 56
+        max_concurrent_shard_requests: 42
+        tls_ca_cert: /etc/ssl/certs/ca.pem
+        dontReportSecureDataChanges: false
+        additional_json_data:
+          nonSecureTest: "nonsecure"
+        additional_secure_json_data:
+          secureTest: "secure"
+
+    - debug:
+        var: result
+
+    - assert:
+        that:
+        - result.changed
+        - result.datasource.basicAuth
+        - result.datasource.basicAuthUser == 'grafana'
+        - result.datasource.access == 'proxy'
+        - result.datasource.database == '[logstash_]YYYY.MM.DD'
+        - not result.datasource.isDefault
+        - result.datasource.jsonData.esVersion == 56
+        - result.datasource.jsonData.interval == 'Daily'
+        - result.datasource.jsonData.maxConcurrentShardRequests == 42
+        - result.datasource.jsonData.timeField == '@timestamp'
+        - not result.datasource.jsonData.tlsAuth
+        - not result.datasource.jsonData.tlsAuthWithCACert
+        - result.datasource.name == 'datasource-elastic'
+        - result.datasource.orgId == 1
+        - result.datasource.password == ''
+        - result.datasource.type == 'elasticsearch'
+        - result.datasource.url == 'https://elastic.example.com:9200'
+        - result.datasource.user == ''
+        - not result.datasource.withCredentials
+        - result.datasource.jsonData.nonSecureTest == 'nonsecure'
+        - result.datasource.secureJsonFields.secureTest == true
+        - result.diff.after.secureJsonData is defined
+
 - name: Delete elasticsearch datasource
   register: result
   grafana_datasource:


### PR DESCRIPTION
##### SUMMARY

fixes #106 
fixes #107
fixes #109 
fixes #110 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_datasource

##### ADDITIONAL INFORMATION

**IMPORTANT: this PR might change previous behaviour!** because:
- As until now (#107) once a datasource where created or updated with any secureJsonData further changes wouldn't be updated and reporting changed=false. With this PR each run will change the fields, which should be the expected result anyways!
- Ad #110: Users don't HAVE to change anything as from now on password isn't save to secureJsonData.password but just password. Runs won't report change=True like above. BUT: they have to switch to secure_password if they want to use encrypted passwords.