### PR TITLE
respect ignore_errors in grafana_annotations.py

### DIFF
--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -237,17 +237,18 @@ class CallbackModule(CallbackBase):
         }
         self._send_annotations(data)
 
-    def v2_runner_on_failed(self, result, **kwargs):
+    def v2_runner_on_failed(self, result, ignore_errors=False, **kwargs):
         text = PLAYBOOK_ERROR_TXT.format(playbook=self.playbook, hostname=self.hostname,
                                          username=self.username, task=result._task,
                                          host=result._host.name, result=self._dump_results(result._result))
-        data = {
-            'time': to_millis(datetime.now()),
-            'text': text,
-            'tags': ['ansible', 'ansible_event_failure', self.playbook, self.hostname]
-        }
-        self.errors += 1
-        self._send_annotations(data)
+        if not ignore_errors:
+            data = {
+                'time': to_millis(datetime.now()),
+                'text': text,
+                'tags': ['ansible', 'ansible_event_failure', self.playbook, self.hostname]
+            }
+            self.errors += 1
+            self._send_annotations(data)
 
     def _send_annotations(self, data):
         if self.dashboard_id:

--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -241,14 +241,15 @@ class CallbackModule(CallbackBase):
         text = PLAYBOOK_ERROR_TXT.format(playbook=self.playbook, hostname=self.hostname,
                                          username=self.username, task=result._task,
                                          host=result._host.name, result=self._dump_results(result._result))
-        if not ignore_errors:
-            data = {
-                'time': to_millis(datetime.now()),
-                'text': text,
-                'tags': ['ansible', 'ansible_event_failure', self.playbook, self.hostname]
-            }
-            self.errors += 1
-            self._send_annotations(data)
+        if ignore_errors:
+            return
+        data = {
+            'time': to_millis(datetime.now()),
+            'text': text,
+            'tags': ['ansible', 'ansible_event_failure', self.playbook, self.hostname]
+        }
+        self.errors += 1
+        self._send_annotations(data)
 
     def _send_annotations(self, data):
         if self.dashboard_id:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Respect `ignore_errors: True` task option in `grafana_annotations.py` and don't send an annotation on these tasks.
Also `self.errors += 1` when the error is not ignored otherwise the playbook is marked as failing in `v2_runner_on_failed` and the execution is marked as red in Grafana.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
