### PR TITLE
[WIP] Fix plugin sanity

### DIFF
--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -17,16 +17,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-import socket
-import getpass
-from datetime import datetime
-
-from ansible.module_utils._text import to_text
-from ansible.module_utils.urls import open_url
-from ansible.plugins.callback import CallbackBase
-
-
 DOCUMENTATION = '''
     name: grafana_annotations
     type: notification
@@ -114,6 +104,15 @@ DOCUMENTATION = '''
         default: []
         type: list
 '''
+
+import json
+import socket
+import getpass
+from datetime import datetime
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.urls import open_url
+from ansible.plugins.callback import CallbackBase
 
 
 PLAYBOOK_START_TXT = """\

--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -28,8 +28,8 @@ from ansible.plugins.callback import CallbackBase
 
 
 DOCUMENTATION = '''
-    callback: grafana_annotations
-    callback_type: notification
+    name: grafana_annotations
+    type: notification
     short_description: send ansible events as annotations on charts to grafana over http api.
     author: "Rémi REY (@rrey)"
     description:

--- a/plugins/lookup/grafana_dashboard.py
+++ b/plugins/lookup/grafana_dashboard.py
@@ -4,7 +4,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-lookup: grafana_dashboard
+name: grafana_dashboard
 author: Thierry Salle (@seuf)
 short_description: list or search grafana dashboards
 description:


### PR DESCRIPTION
##### SUMMARY
According to https://github.com/ansible/ansible/issues/71795, `<plugin_type>:` should be replaced by `name:` in the plugin docs. Also according to https://github.com/ansible/ansible/issues/71798, `callback_type` should be renamed to `type`. Finally, imports should be below the docs (but before anything else), as will be reported by ansible/ansible#71734.

I marked this as [WIP] since it should wait until ansible/ansible#71734 is finalized.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection
