### PR TITLE
Remove trailing slash from provided grafana url

### DIFF
--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -22,6 +22,10 @@ from ansible.module_utils.urls import url_argument_spec
 __metaclass__ = type
 
 
+def clean_url(url):
+    return url.rstrip("/")
+
+
 def grafana_argument_spec():
     argument_spec = url_argument_spec()
 

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -136,7 +136,7 @@ from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, clean_url
 
 __metaclass__ = type
 
@@ -516,6 +516,8 @@ def main():
         required_together=[['url_username', 'url_password', 'org_id']],
         mutually_exclusive=[['url_username', 'grafana_api_key'], ['uid', 'slug'], ['path', 'dashboard_id']],
     )
+
+    module.params["grafana_url"] = clean_url(module.params["grafana_url"])
 
     if 'message' in module.params:
         module.fail_json(msg="'message' is reserved keyword, please change this parameter to 'commit_message'")

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -454,7 +454,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url, url_argument_spec, basic_auth_header
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive, clean_url
 
 
 def compare_datasources(new, current, compareSecureData=True):
@@ -589,7 +589,7 @@ class GrafanaInterface(object):
 
     def __init__(self, module):
         self._module = module
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = clean_url(module.params.get("url"))
         # {{{ Authentication header
         self.headers = {"Content-Type": "application/json"}
         if module.params.get('grafana_api_key', None):

--- a/plugins/modules/grafana_folder.py
+++ b/plugins/modules/grafana_folder.py
@@ -156,7 +156,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive, clean_url
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils._text import to_text
 
@@ -174,7 +174,7 @@ class GrafanaFolderInterface(object):
         else:
             self.headers["Authorization"] = basic_auth_header(module.params['url_username'], module.params['url_password'])
         # }}}
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = clean_url(module.params.get("url"))
         grafana_version = self.get_version()
         if grafana_version["major"] < 5:
             self._module.fail_json(failed=True, msg="Folders API is available starting Grafana v5")

--- a/plugins/modules/grafana_notification_channel.py
+++ b/plugins/modules/grafana_notification_channel.py
@@ -420,7 +420,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_text
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, clean_url
 
 
 class GrafanaAPIException(Exception):
@@ -803,6 +803,8 @@ def main():
             ['type', 'webhook', ['webhook_url']]
         ]
     )
+
+    module.params["grafana_url"] = clean_url(module.params["grafana_url"])
 
     if module.params['state'] == 'present':
         result = grafana_create_or_update_notification_channel(module, module.params)

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -162,7 +162,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive, clean_url
 
 __metaclass__ = type
 
@@ -178,7 +178,7 @@ class GrafanaTeamInterface(object):
         else:
             self.headers["Authorization"] = basic_auth_header(module.params['url_username'], module.params['url_password'])
         # }}}
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = clean_url(module.params.get("url"))
         grafana_version = self.get_version()
         if grafana_version["major"] < 5:
             self._module.fail_json(failed=True, msg="Teams API is available starting Grafana v5")

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -155,7 +155,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
-from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive
+from ansible_collections.community.grafana.plugins.module_utils.base import grafana_argument_spec, grafana_required_together, grafana_mutually_exclusive, clean_url
 
 __metaclass__ = type
 
@@ -168,7 +168,7 @@ class GrafanaUserInterface(object):
         self.headers = {"Content-Type": "application/json"}
         self.headers["Authorization"] = basic_auth_header(module.params['url_username'], module.params['url_password'])
         # }}}
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = clean_url(module.params.get("url"))
 
     def _send_request(self, url, data=None, headers=None, method="GET"):
         if data is not None:


### PR DESCRIPTION
Remove trailing slashes from the Grafana URL to avoid double slashes when concatenating the URI

Closes: #135
