### PR TITLE
Add rust and cargo in alpine deps to allow ansible install to work again

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -72,7 +72,7 @@ jobs:
     steps:
 
       - name: Install requirements on alpine
-        run: apk add bash git gcc python3-dev libc-dev libffi-dev openssl-dev
+        run: apk add bash git gcc python3-dev libc-dev libffi-dev openssl-dev rust cargo
 
       - name: Check out code
         uses: actions/checkout@v1


### PR DESCRIPTION
Add rust and cargo in the install deps to allow cryptography installation to work again.

See related drama: https://github.com/pyca/cryptography/issues/5771
