### PR TITLE
Fix 155: Enable tlsAuthWithCACert when using CA Cert

### DIFF
--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -532,6 +532,7 @@ def get_datasource_payload(data):
         json_data['tlsAuth'] = False
         json_data['tlsAuthWithCACert'] = False
         if data.get('tls_ca_cert'):
+            json_data['tlsAuthWithCACert'] = True
             secure_json_data['tlsCACert'] = data['tls_ca_cert']
 
     if data.get('tls_skip_verify'):

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -34,7 +34,7 @@
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
     - not result.datasource.jsonData.tlsAuth
-    - not result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-elastic'
     - result.datasource.orgId == 1
     - result.datasource.password == ''
@@ -80,7 +80,7 @@
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
     - not result.datasource.jsonData.tlsAuth
-    - not result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-elastic'
     - result.datasource.orgId == 1
     - result.datasource.password == ''
@@ -125,7 +125,7 @@
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
     - not result.datasource.jsonData.tlsAuth
-    - not result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-elastic'
     - result.datasource.orgId == 1
     - result.datasource.password == ''
@@ -175,7 +175,7 @@
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
     - not result.datasource.jsonData.tlsAuth
-    - not result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-elastic'
     - result.datasource.orgId == 1
     - result.datasource.password == ''
@@ -226,7 +226,7 @@
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
     - not result.datasource.jsonData.tlsAuth
-    - not result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-elastic'
     - result.datasource.orgId == 1
     - result.datasource.password == ''

--- a/tests/integration/targets/grafana_datasource/tasks/influx.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/influx.yml
@@ -46,7 +46,7 @@
     - result.datasource.isDefault == false
     - result.datasource.jsonData.timeInterval == '>10s'
     - result.datasource.jsonData.tlsAuth == false
-    - result.datasource.jsonData.tlsAuthWithCACert == false
+    - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-influxdb'
     - result.datasource.orgId == 1
     - result.datasource.password == ''


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.grafana/issues/155

As described in https://github.com/ansible-collections/community.grafana/issues/155 the option `With CA Cert` will not be enabled if only the parameter `tls_ca_cert` is set.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_datasource.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I reproduced the issue https://github.com/ansible-collections/community.grafana/issues/155 with prometheus datasource. 

1. Create Root CA cert + key
2. Self sign Root CA
3. Create CSR for datasource Domain
4. Sign CSR with Root CA
5. Execute playbook with Root CA as multi line string var




<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- name: Create Loki datasource
  community.grafana.grafana_datasource:
    name: "Prom"
    grafana_url: "https://localhost:3000"
    ds_type: "prometheus"
    ds_url: "https://your.domain"
    basic_auth_user: "..."
    basic_auth_password: "..."
    tls_ca_cert: |
         -----BEGIN CERTIFICATE-----
         MIIDRTCCAi2gAwIBA.....ucBXA==
         ...
         -----END CERTIFICATE-----"
    validate_certs: False
    is_default: no
```
