### PR TITLE
grafana_dashboard lookup: fix passing API key

### DIFF
--- a/changelogs/fragments/158-grafana_dashboard-lookup-api-key.yml
+++ b/changelogs/fragments/158-grafana_dashboard-lookup-api-key.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+- grafana_dashboard lookup - Providing a mangled version of the API key is no
+  longer preferred.
+bugfixes:
+- grafana_dashboard lookup - All valid API keys can be used, not just keys
+  ending in '=='.


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The code assumed a static amount of base64 padding, which is not always correct. The simplest way to fix this is to parse the arguments correctly and trust the user to pass the correct API key.

(Even better would be to use plugin options and deprecate the k=v string parsing, but that's more work than I'm prepared to do at the moment.) 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_dashboard lookup

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before:
```
ec2-user@pandora ~ $ ansible localhost -m debug -a "msg={{ q('grafana_dashboard', 'grafana_url=https://graphs.x.mail.umich.edu grafana_api_key=eyJrIjoiajZwQUNZRlVJM2FuTjRmM0hlUFpJU2xTUFFRV2RTenYiLCJuIjoidGVzdDEiLCJpZCI6MX0=') }}"
localhost | FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'grafana_dashboard'. Error was a <class 'ansible.errors.AnsibleError'>, original message: grafana_dashboard lookup plugin needs key=value pairs, but received ['grafana_url=https://graphs.x.mail.umich.edu grafana_api_key=eyJrIjoiajZwQUNZRlVJM2FuTjRmM0hlUFpJU2xTUFFRV2RTenYiLCJuIjoidGVzdDEiLCJpZCI6MX0=']"
}

ec2-user@pandora ~ $ ansible localhost -m debug -a "msg={{ q('grafana_dashboard', 'grafana_url=https://graphs.x.mail.umich.edu grafana_api_key=eyJrIjoiajZwQUNZRlVJM2FuTjRmM0hlUFpJU2xTUFFRV2RTenYiLCJuIjoidGVzdDEiLCJpZCI6MX0') }}"
localhost | FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'grafana_dashboard'. Error was a <class 'ansible.plugins.lookup.grafana_dashboard.GrafanaAPIException'>, original message: Unable to search dashboards : HTTP Error 401: Unauthorized"
}
```

After:
```
ec2-user@pandora ~ $ ansible localhost -m debug -a "msg={{ q('grafana_dashboard', 'grafana_url=https://graphs.x.mail.umich.edu grafana_api_key=eyJrIjoiajZwQUNZRlVJM2FuTjRmM0hlUFpJU2xTUFFRV2RTenYiLCJuIjoidGVzdDEiLCJpZCI6MX0=') }}"
localhost | SUCCESS => {
    "msg": [
        {
            "id": 2,
            "isStarred": false,
            "slug": "",
            "sortMeta": 0,
            "tags": [],
            "title": "dashboards",
            "type": "dash-folder",
            "uid": "hPQaB-QZk",
            "uri": "db/dashboards",
            "url": "/dashboards/f/hPQaB-QZk/dashboards"
        },
```