### PR TITLE
dashboard: Fail if the target directory does not exist

### DIFF
--- a/changelogs/fragments/1.2.2.yml
+++ b/changelogs/fragments/1.2.2.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- grafana_dashboard now explicitely fails if the folder doesn't exist upon creation.
+  It would previously silently pass but not create the dashboard.
+  (https://github.com/ansible-collections/community.grafana/issues/153)

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -340,10 +340,7 @@ def grafana_create_dashboard(module, data):
     if grafana_version >= 5:
         folder_exists, folder_id = grafana_folder_exists(module, data['grafana_url'], data['folder'], headers)
         if folder_exists is False:
-            result['msg'] = "Dashboard folder '%s' does not exist." % data['folder']
-            result['uid'] = uid
-            result['changed'] = False
-            return result
+            raise GrafanaAPIException("Dashboard folder '%s' does not exist." % data['folder'])
 
         payload['folderId'] = folder_id
 
@@ -385,10 +382,6 @@ def grafana_create_dashboard(module, data):
             result['msg'] = "Dashboard %s unchanged." % payload['dashboard']['title']
             result['changed'] = False
     else:
-        # create
-        if folder_exists is True:
-            payload['folderId'] = folder_id
-
         # Ensure there is no id in payload
         if 'id' in payload['dashboard']:
             del payload['dashboard']['id']

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
@@ -1,0 +1,33 @@
+---
+- name: copy dashboard file
+  copy:
+    src: "files/dashboard.json"
+    dest: "/tmp/dashboard.json"
+
+- block:
+  - name: Check import grafana dashboard from file to unknown folder fails
+    grafana_dashboard:
+      grafana_url: "{{ grafana_url }}"
+      grafana_user: "{{ grafana_username }}"
+      grafana_password: "{{ grafana_password }}"
+      state: present
+      commit_message: Updated by ansible
+      path: /tmp/dashboard.json
+      overwrite: true
+      folder: inexistent
+    register: result
+    ignore_errors: true
+
+- debug:
+    var: result
+
+- set_fact:
+    # XXX: Too many quotes of different types to do inline.
+    #      I did not manage to find a good way of having it inline.
+    expected_error: "error : Dashboard folder 'inexistent' does not exist."
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.failed == true"
+      - "result.msg == expected_error"

--- a/tests/integration/targets/grafana_dashboard/tasks/main.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/main.yml
@@ -3,3 +3,4 @@
   - include: delete-dashboard.yml
   - include: dashboard-from-id.yml
   - include: dashboard-from-file.yml
+  - include: dashboard-folder-destination.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The `grafana_dashboard` module currently silently fails (that is, succeeds) to add a new dashboard if the directory in which the dashboard should be put doesn't exist.

I believe this is unintuitive and at least lost me quite some time trying to understanding why I did not see my dashboard when everything was fine.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

In order to reproduce:
- Setup a grafana instance
- Add a new dashboard to it, to a directory that does not exists
- Expected: it fails? Or creates the folder?
- Currently: it succeeds but the dashboard is not uploaded

#### To the reviewers:
I have made directly a PR as I think this is a bug? Let me know if you want an issue to discuss this first :)

Also, if you accept that change I was not sure how to add a changelog entry, and would appreciate guidance.

Thanks for your time!