### PR TITLE
Better idempotence report when creating a dashboard in a folder

### DIFF
--- a/tests/integration/targets/grafana_dashboard/files/dashboard.json
+++ b/tests/integration/targets/grafana_dashboard/files/dashboard.json
@@ -1,85 +1,85 @@
 {
-    "annotations": {
-      "list": [
-        {
-          "builtIn": 1,
-          "datasource": "-- Grafana --",
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations & Alerts",
-          "type": "dashboard"
-        }
-      ]
-    },
-    "editable": true,
-    "gnetId": null,
-    "graphTooltip": 0,
-    "id": 11,
-    "links": [],
-    "panels": [
+  "annotations": {
+    "list": [
       {
-        "content": "\n# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n\n\n",
-        "gridPos": {
-          "h": 9,
-          "w": 12,
-          "x": 0,
-          "y": 0
-        },
-        "id": 2,
-        "mode": "markdown",
-        "options": {},
-        "targets": [
-          {
-            "expr": "",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "refId": "A"
-          }
-        ],
-        "timeFrom": null,
-        "timeShift": null,
-        "title": "Panel Title",
-        "type": "text"
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
       }
-    ],
-    "schemaVersion": 18,
-    "style": "dark",
-    "tags": [],
-    "templating": {
-      "list": []
-    },
-    "time": {
-      "from": "now-6h",
-      "to": "now"
-    },
-    "timepicker": {
-      "refresh_intervals": [
-        "5s",
-        "10s",
-        "30s",
-        "1m",
-        "5m",
-        "15m",
-        "30m",
-        "1h",
-        "2h",
-        "1d"
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 11,
+  "links": [],
+  "panels": [
+    {
+      "content": "\n# Title\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n\n\n",
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "mode": "markdown",
+      "options": {},
+      "targets": [
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "A"
+        }
       ],
-      "time_options": [
-        "5m",
-        "15m",
-        "1h",
-        "6h",
-        "12h",
-        "24h",
-        "2d",
-        "7d",
-        "30d"
-      ]
-    },
-    "timezone": "",
-    "title": "test",
-    "uid": "9ZlJIhhWk",
-    "version": 7
-  }
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Panel Title",
+      "type": "text"
+    }
+  ],
+  "schemaVersion": 18,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "test",
+  "uid": "9ZlJIhhWk",
+  "version": 7
+}

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-in-folder.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-in-folder.yml
@@ -1,0 +1,80 @@
+---
+- debug: msg="{{ lookup('file', '/tmp/dashboard.json') }}"
+
+- name: Dump the dashboard to a file
+  copy:
+    content: "{{ lookup('file', 'files/dashboard.json') | from_json | combine({'title': 'in-folder', 'uid': 'dashboard-in-folder'}) | to_nice_json(indent=2) }}"
+    dest: "/tmp/dashboard.json"
+
+- debug: msg="{{ lookup('file', '/tmp/dashboard.json') }}"
+
+- name: Create a Folder
+  grafana_folder:
+      url: "{{ grafana_url }}"
+      url_username: "{{ grafana_username }}"
+      url_password: "{{ grafana_password }}"
+      title: "my/folder"
+      state: present
+
+
+- name: Check import grafana dashboard in a custom folder
+  grafana_dashboard:
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: present
+    commit_message: Updated by ansible
+    path: /tmp/dashboard.json
+    folder: my/folder
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.msg == 'Dashboard in-folder created'"
+
+- name: Check import grafana dashboard in a custom folder idempotency
+  grafana_dashboard:
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: present
+    commit_message: Updated by ansible
+    path: /tmp/dashboard.json
+    folder: my/folder
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.msg == 'Dashboard in-folder unchanged.'"
+
+- name: Check we can move the dashboard in a different folder
+  grafana_dashboard:
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: present
+    commit_message: Updated by ansible
+    path: /tmp/dashboard.json
+    folder: General
+    overwrite: true
+  register: result
+
+- debug:
+    var: result
+
+- assert:
+    that:
+      # FIXME: would be great to be able to check that just the folder has changed
+      - "result.changed == true"
+      - "result.msg == 'Dashboard in-folder updated'"
+      - "result.uid == 'dashboard-in-folder'"

--- a/tests/integration/targets/grafana_dashboard/tasks/main.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/main.yml
@@ -3,3 +3,4 @@
   - include: delete-dashboard.yml
   - include: dashboard-from-id.yml
   - include: dashboard-from-file.yml
+  - include: dashboard-in-folder.yml


### PR DESCRIPTION
##### SUMMARY

Previously, whenever you would upload a dashboard to a custom folder, the status would _always_ be reported as `changed`, as the `folderId` is never included in the return value, but was in our `payload`.

The current solution is not perfect, but would at least not report `changed` when nothing changed, and should not break any other workflows.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

In order to understand and reproduce the issue, running the added integration test without the patch would fail, as the second upload would fail.

For context, https://github.com/grafana/grafana/issues/12491 is also relevant
