### PR TITLE
grafana_team: unable to use spaces or other utf-8 chars in name/title

### DIFF
--- a/changelogs/fragments/1.2.2.yml
+++ b/changelogs/fragments/1.2.2.yml
@@ -2,3 +2,5 @@ bugfixes:
 - grafana_dashboard now explicitely fails if the folder doesn't exist upon creation.
   It would previously silently pass but not create the dashboard.
   (https://github.com/ansible-collections/community.grafana/issues/153)
+- grafana_team now able to handle spaces and other utf-8 chars in the name parameter.
+  (https://github.com/ansible-collections/community.grafana/issues/164)

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -173,6 +173,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible.module_utils._text import to_text
 import ansible_collections.community.grafana.plugins.module_utils.base as base
+from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 
@@ -238,7 +239,7 @@ class GrafanaTeamInterface(object):
         return response
 
     def get_team(self, name):
-        url = "/api/teams/search?name={team}".format(team=name)
+        url = "/api/teams/search?name={team}".format(team=quote(name))
         response = self._send_request(url, headers=self.headers, method="GET")
         if not response.get("totalCount") <= 1:
             raise AssertionError("Expected 1 team, got %d" % response["totalCount"])


### PR DESCRIPTION
<!--- Verify first that your issue is not already reported on GitHub -->
<!--- Also test if the latest release and devel branch are affected too -->
<!--- Complete *all* sections as described, this form is processed automatically -->

##### SUMMARY
<!--- Explain the problem briefly below -->
grafana_team: unable to use spaces or other utf-8 chars in name/title

Same PR like for grafana_folder #79 

Fix issue #164 

##### ISSUE TYPE
- Bug Report

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below, use your best guess if unsure -->
grafana_team

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
ansible 2.9.15
  config file = /mnt/c/DeveloperArea/Telia/moncap-repo/ansible.cfg
  configured module search path = ['/home/myuser/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.9/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.9.0 (default, Oct  6 2020, 00:00:00) [GCC 10.2.1 20200826 (Red Hat 10.2.1-3)]

collection:
community.grafana 1.2.1
```

##### CONFIGURATION
<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
```paste below

```

##### OS / ENVIRONMENT
<!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
Ubuntu 18.04.3 LTS

##### STEPS TO REPRODUCE
<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->

Procedure described in : #164

<!--- HINT: You can paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!--- Describe what you expected to happen when running the steps above -->
Teams should be created.

##### ACTUAL RESULTS
<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
Error, because not URL quote for the get_folder API query.
<!--- Paste verbatim command output between quotes -->
```paste below
msg": "Grafana Folders API answered with HTTP -1"
```
