### PR TITLE
add redis-datasource

### DIFF
--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -39,6 +39,7 @@ options:
     - sni-thruk-datasource
     - camptocamp-prometheus-alertmanager-datasource
     - loki
+    - redis-datasource
     type: str
   ds_url:
     description:
@@ -660,6 +661,7 @@ def main():
                               'alexanderzobnin-zabbix-datasource',
                               'camptocamp-prometheus-alertmanager-datasource',
                               'sni-thruk-datasource',
+                              'redis-datasource',
                               'loki'], required=True),
         ds_url=dict(required=True, type='str'),
         access=dict(default='proxy', choices=['proxy', 'direct']),

--- a/tests/integration/targets/grafana_datasource/tasks/main.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/main.yml
@@ -8,5 +8,6 @@
   - include: thruk.yml
   - include: loki.yml
   - include: zabbix.yml
+  - include: redis.yml
 
 ...

--- a/tests/integration/targets/grafana_datasource/tasks/redis.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/redis.yml
@@ -58,7 +58,8 @@
     grafana_password: "{{ grafana_password }}"
     org_id: '1'
     ds_type: redis-datasource
-    ds_url: https://redis.company.com:6379
+    ds_url: https://redisnew.company.com:6379
+    time_interval: 1m
 
 - debug:
     var: result

--- a/tests/integration/targets/grafana_datasource/tasks/redis.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/redis.yml
@@ -72,7 +72,7 @@
     - result.datasource.name == 'datasource-redis'
     - result.datasource.orgId == 1
     - result.datasource.type == 'redis-datasource'
-    - result.datasource.url == 'https://redis.company.com:6379'
+    - result.datasource.url == 'https://redisnew.company.com:6379'
 
 - name: Delete redis-datasource datasource  
   register: result

--- a/tests/integration/targets/grafana_datasource/tasks/redis.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/redis.yml
@@ -1,0 +1,106 @@
+- name: Create redis datasource
+  register: result
+  grafana_datasource:
+    name: datasource-redis
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: redis-datasource
+    ds_url: https://redis.company.com:6379
+    time_interval: 1m
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.name == 'datasource-redis'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'redis-datasource'
+    - result.datasource.url == 'https://redis.company.com:6379'
+    - "result.msg == 'Datasource datasource-redis created'"
+
+- name: Check redis-datasource datasource creation idempotency
+  register: result
+  grafana_datasource:
+    name: datasource-redis
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: redis-datasource
+    ds_url: https://redis.company.com:6379
+    time_interval: 1m
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - not result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.name == 'datasource-redis'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'redis-datasource'
+    - result.datasource.url == 'https://redis.company.com:6379'
+
+- name: update redis-datasource datasource creation
+  register: result
+  grafana_datasource:
+    name: datasource-redis
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: redis-datasource
+    ds_url: https://redis.company.com:6379
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.name == 'datasource-redis'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'redis-datasource'
+    - result.datasource.url == 'https://redis.company.com:6379'
+
+- name: Delete redis-datasource datasource  
+  register: result
+  grafana_datasource:
+    name: datasource-redis
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: redis-datasource
+    ds_url: https://redis.company.com:6379
+    state: absent
+
+- assert:
+    that:
+    - result.changed
+
+- name: Delete redis-datasource datasource (idempotency)
+  register: result
+  grafana_datasource:
+    name: datasource-redis
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: redis-datasource
+    ds_url: https://redis.company.com:6379
+    state: absent
+
+- assert:
+    that:
+    - not result.changed


### PR DESCRIPTION
##### SUMMARY

A simple insertion of `redis-datasource` as accepted value for `ds_type`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`community.grafana.grafana_datasource`

##### ADDITIONAL INFORMATION

Both authenticated and non-authenticated Redis instances work that way (already supported from module arguments `database` and `password`) only thing I haven't found yet is how to change type from Standalone to e.g. Sentinel, Cluster.

<!--- Paste verbatim command output below, e.g. before and after your change -->

Example task for creating a Redis datasource:

```yaml
- name: Create grafana redis datasource
  community.grafana.grafana_datasource:
    name: "redis-local-test"
    grafana_url: "{{ grafana.url }}"
    grafana_api_key: "{{ grafana.api_key }}"
    ds_type: "redis-datasource"
    ds_url: "redis://redis:6379"
```

A task like the one above will output the following: 
```json
changed: [grafana-host] => {
    "changed": true,
    "datasource": {
        "access": "proxy",
        "basicAuth": false,
        "basicAuthPassword": "",
        "basicAuthUser": "",
        "database": "",
        "id": 10,
        "isDefault": false,
        "jsonData": {
            "tlsAuth": false,
            "tlsAuthWithCACert": false
        },
        "name": "redis-local-test",
        "orgId": 1,
        "password": "",
        "readOnly": false,
        "secureJsonFields": {},
        "type": "redis-datasource",
        "typeLogoUrl": "",
        "uid": "i4umcIinz",
        "url": "redis://redis:6379",
        "user": "",
        "version": 1,
        "withCredentials": false
    },
```
