### PR TITLE
Add Grafana release 8.x to tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        grafana_version: ["6.7.4", "7.0.6",  "7.1.3"]
+        grafana_version: ["6.7.4", "7.0.6",  "7.1.3", "8.1.2"]
         ansible_version: ["stable-2.9", "stable-2.10", "devel"]
         python_version: ["3.6"]
     container:


### PR DESCRIPTION
##### SUMMARY
Relates to #176.

This change will also test against Grafana version 8.x. Currently 8.1.2 - the current latest version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Any component/module.

##### ADDITIONAL INFORMATION
The collection is currently not properly working with Grafana version 8.x. Let's add some tests and fix the resulting issues.