### PR TITLE
fix: support trailing slash in grafana_url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ Grafana Collection Release Notes
 .. contents:: Topics
 
 
+v1.2.3
+======
+
+Bugfixes
+--------
+
+- Fix issue with trailing '/' in provided grafana_url. The modules now support values with trailing slashes.
+
 v1.2.2
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -94,3 +94,11 @@ releases:
     - 1.2.2.yml
     - 158-grafana_dashboard-lookup-api-key.yml
     release_date: '2021-09-08'
+  1.2.3:
+    changes:
+      bugfixes:
+      - Fix issue with trailing '/' in provided grafana_url. The modules now support
+        values with trailing slashes.
+    fragments:
+    - 1.2.3.yml
+    release_date: '2021-09-14'

--- a/changelogs/fragments/1.2.3.yml
+++ b/changelogs/fragments/1.2.3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix issue with trailing '/' in provided grafana_url. The modules now support values with trailing slashes. 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: grafana
-version: 1.2.2
+version: 1.2.3
 readme: README.md
 authors:
 - Rémi REY (@rrey)

--- a/plugins/modules/grafana_folder.py
+++ b/plugins/modules/grafana_folder.py
@@ -187,7 +187,7 @@ class GrafanaFolderInterface(object):
         else:
             self.headers["Authorization"] = basic_auth_header(module.params['url_username'], module.params['url_password'])
         # }}}
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = base.clean_url(module.params.get("url"))
         if module.params.get("skip_version_check") is False:
             try:
                 grafana_version = self.get_version()

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -193,7 +193,7 @@ class GrafanaTeamInterface(object):
         else:
             self.headers["Authorization"] = basic_auth_header(module.params['url_username'], module.params['url_password'])
         # }}}
-        self.grafana_url = module.params.get("url")
+        self.grafana_url = base.clean_url(module.params.get("url"))
         if module.params.get("skip_version_check") is False:
             try:
                 grafana_version = self.get_version()

--- a/tests/integration/targets/grafana_dashboard/defaults/main.yml
+++ b/tests/integration/targets/grafana_dashboard/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"
 

--- a/tests/integration/targets/grafana_datasource/defaults/main.yml
+++ b/tests/integration/targets/grafana_datasource/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"
 

--- a/tests/integration/targets/grafana_folder/defaults/main.yml
+++ b/tests/integration/targets/grafana_folder/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"
 

--- a/tests/integration/targets/grafana_notification_channel/defaults/main.yml
+++ b/tests/integration/targets/grafana_notification_channel/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"
 

--- a/tests/integration/targets/grafana_team/defaults/main.yml
+++ b/tests/integration/targets/grafana_team/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"
 

--- a/tests/integration/targets/grafana_team/tasks/create_user.yml
+++ b/tests/integration/targets/grafana_team/tasks/create_user.yml
@@ -1,6 +1,6 @@
 - name: Create John Doe for tests purpose through uri module
   uri:
-    url: "{{ grafana_url }}/api/admin/users"
+    url: "{{ grafana_url }}api/admin/users"
     method: POST
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"
@@ -15,7 +15,7 @@
 
 - name: Create Jane Doe for tests purpose through uri module
   uri:
-    url: "{{ grafana_url }}/api/admin/users"
+    url: "{{ grafana_url }}api/admin/users"
     method: POST
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"

--- a/tests/integration/targets/grafana_user/defaults/main.yml
+++ b/tests/integration/targets/grafana_user/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-grafana_url: "http://grafana:3000"
+grafana_url: "http://grafana:3000/"
 grafana_username: "admin"
 grafana_password: "admin"

--- a/tests/integration/targets/grafana_user/tasks/main.yml
+++ b/tests/integration/targets/grafana_user/tasks/main.yml
@@ -40,7 +40,7 @@
 
 - name: Check user creation with Grafana API
   uri:
-    url: "{{ grafana_url }}/api/users/lookup?loginOrEmail=harley"
+    url: "{{ grafana_url }}api/users/lookup?loginOrEmail=harley"
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"
     force_basic_auth: yes
@@ -109,7 +109,7 @@
 
 - name: Check user creation with Grafana API
   uri:
-    url: "{{ grafana_url }}/api/users/lookup?loginOrEmail=batman"
+    url: "{{ grafana_url }}api/users/lookup?loginOrEmail=batman"
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"
     force_basic_auth: yes
@@ -145,7 +145,7 @@
 
 - name: Check user update with Grafana API
   uri:
-    url: "{{ grafana_url }}/api/users/lookup?loginOrEmail=batman"
+    url: "{{ grafana_url }}api/users/lookup?loginOrEmail=batman"
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"
     force_basic_auth: yes
@@ -188,7 +188,7 @@
 
 - name: Check user deletion with Grafana API (expect 404 Not Found)
   uri:
-    url: "{{ grafana_url }}/api/users/lookup?loginOrEmail=batman"
+    url: "{{ grafana_url }}api/users/lookup?loginOrEmail=batman"
     user: "{{ grafana_username }}"
     password: "{{ grafana_password }}"
     force_basic_auth: yes


### PR DESCRIPTION
##### SUMMARY

Support different grafana url format that could finish with with a slash or not depending on user habit.
Fixes #183"

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
plugins/modules/grafana_datasource.py
plugins/modules/grafana_folder.py
plugins/modules/grafana_team.py
plugins/modules/grafana_user.py

##### ADDITIONAL INFORMATION
N/A