### PR TITLE
Datasource - Add 'AWS SDK Default' as an auth type

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,13 @@ Grafana Collection Release Notes
 ================================
 
 .. contents:: Topics
+v1.3.1
+======
 
+Minor Changes
+-------------
+
+- community.grafana.grafana_datasource supports aws_auth_type of default.
 
 v1.3.0
 ======

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/grafana)](https://codecov.io/gh/ansible-collections/community.grafana)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-15-orange.svg?style=flat-square)](#contributors-)
-<!-- ALL-CONTRIBUTORS-BADGE:END --> 
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This repo hosts the `community.grafana` Ansible Collection.
 
@@ -48,7 +48,7 @@ You can also include it in a `requirements.yml` file and install it via `ansible
 ---
 collections:
   - name: community.grafana
-    version: 1.2.0
+    version: 1.3.1
 ```
 
 ### Using modules from the Grafana Collection in your playbooks

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,10 +1,10 @@
 namespace: community
 name: grafana
-version: 1.3.0
+version: 1.3.1
 readme: README.md
 authors:
-- Rémi REY (@rrey)
-- Thierry Sallé (@seuf)
+  - Rémi REY (@rrey)
+  - Thierry Sallé (@seuf)
 description: Collection allowing to interact with Grafana APIs
 license_file: LICENSE
 tags:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -213,6 +213,7 @@ options:
     - keys
     - credentials
     - arn
+    - default
     type: str
   aws_default_region:
     description:
@@ -688,7 +689,7 @@ def main():
         tsdb_resolution=dict(type='str', default='second', choices=['second', 'millisecond']),
         sslmode=dict(default='disable', choices=['disable', 'require', 'verify-ca', 'verify-full']),
         trends=dict(default=False, type='bool'),
-        aws_auth_type=dict(default='keys', choices=['keys', 'credentials', 'arn']),
+        aws_auth_type=dict(default='keys', choices=['keys', 'credentials', 'arn', 'default']),
         aws_default_region=dict(default='us-east-1', choices=['ap-northeast-1', 'ap-northeast-2', 'ap-southeast-1', 'ap-southeast-2', 'ap-south-1',
                                                               'ca-central-1',
                                                               'cn-north-1', 'cn-northwest-1',


### PR DESCRIPTION
##### SUMMARY
Fixes #205 

Allows setting the auth type to `default`

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
grafana_datasource

##### ADDITIONAL INFORMATION
This allows you to fall back to using the `instance profile` of the EC2 Instance you are running on.

