### PR TITLE
Use encrypted passwords for datasources

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See LICENCE to see the full text.
 
 Any contribution is welcome and we only ask contributors to:
 * Provide *at least* integration tests for any contribution.
-* Create an issues for any significant contribution that would change a large portion of the code base.
+* Create an issue for any significant contribution that would change a large portion of the code base.
 
 ## Contributors ✨
 

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -250,12 +250,14 @@ options:
   aws_access_key:
     description:
     - AWS access key for CloudWatch datasource type when C(aws_auth_type) is C(keys)
+    - Stored as secure data, see C(enforce_secure_data) and notes!
     default: ''
     required: false
     type: str
   aws_secret_key:
     description:
     - AWS secret key for CloudWatch datasource type when C(aws_auth_type) is C(keys)
+    - Stored as secure data, see C(enforce_secure_data) and notes!
     default: ''
     required: false
     type: str


### PR DESCRIPTION
##### SUMMARY
Fixes #204 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_datasource

##### ADDITIONAL INFORMATION
- See [my comment](https://github.com/ansible-collections/community.grafana/issues/204#issuecomment-1047130250)
- Use of encrypted passwords for datasources is possible since Grafana v6.2.0. If accepted, this changes will make grafana_datasource module not compatible with Grafana v6.1.6 (released in Apr. 2019) and ealier.

