### PR TITLE
test(datasource): Add unit tests for grafana_datasource module

### DIFF
--- a/changelogs/fragments/add-units-datasource.yml
+++ b/changelogs/fragments/add-units-datasource.yml
@@ -1,0 +1,2 @@
+trivial:
+  - Add unit tests coverage for datasource module.

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -692,8 +692,7 @@ class GrafanaInterface(object):
         self._send_request(url, data=data, headers=self.headers, method='POST')
 
 
-def main():
-    # use the predefined argument spec for url
+def setup_module_object():
     argument_spec = base.grafana_argument_spec()
 
     argument_spec.update(
@@ -776,6 +775,11 @@ def main():
             ['es_version', 70, ['max_concurrent_shard_requests']]
         ],
     )
+    return module
+
+
+def main():
+    module = setup_module_object()
 
     state = module.params['state']
     name = module.params['name']

--- a/tests/unit/modules/grafana/grafana_datasource/test_grafana_datasource.py
+++ b/tests/unit/modules/grafana/grafana_datasource/test_grafana_datasource.py
@@ -1,0 +1,204 @@
+from __future__ import (absolute_import, division, print_function)
+
+from unittest import TestCase
+from unittest.mock import call, patch, MagicMock
+from ansible_collections.community.grafana.plugins.modules import grafana_datasource
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils import basic
+from ansible.module_utils.urls import basic_auth_header
+import json
+
+__metaclass__ = type
+
+
+def set_module_args(args):
+    """prepare arguments so that they will be picked up during module creation"""
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+def exit_json(*args, **kwargs):
+    """function to patch over exit_json; package return data into an exception"""
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    """function to patch over fail_json; package return data into an exception"""
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+class AnsibleExitJson(Exception):
+    """Exception class to be raised by module.exit_json and caught by the test case"""
+    pass
+
+
+class AnsibleFailJson(Exception):
+    """Exception class to be raised by module.fail_json and caught by the test case"""
+    pass
+
+
+class GrafanaDatasource(TestCase):
+
+    def setUp(self):
+        self.authorization = basic_auth_header("admin", "admin")
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+    def test_payload_prometheus(self):
+        expected_payload = {
+            'access': 'proxy',
+            'basicAuth': False,
+            'database': '',
+            'isDefault': False,
+            'jsonData': {
+                'tlsAuth': False,
+                'tlsAuthWithCACert': False,
+                'tlsSkipVerify': True
+            },
+            'name': 'openshift_prometheus',
+            'orgId': 1,
+            'secureJsonData': {},
+            'type': 'prometheus',
+            'url': 'https://openshift-monitoring.company.com',
+            'user': '',
+            'withCredentials': False
+        }
+        set_module_args({
+            'url': 'https://grafana.example.com',
+            'url_username': 'admin',
+            'url_password': 'admin',
+            'name': 'openshift_prometheus',
+            'ds_type': 'prometheus',
+            'ds_url': 'https://openshift-monitoring.company.com',
+            'access': 'proxy',
+            'tls_skip_verify': 'true',
+        })
+        module = grafana_datasource.setup_module_object()
+        payload = grafana_datasource.get_datasource_payload(module.params)
+        self.assertEqual(payload, expected_payload)
+
+    def test_payload_prometheus_with_basic_auth(self):
+        expected_payload = {
+            'access': 'proxy',
+            'basicAuth': True,
+            'basicAuthUser': 'admin',
+            'database': '',
+            'isDefault': False,
+            'jsonData': {
+                'tlsAuth': False,
+                'tlsAuthWithCACert': False,
+                'tlsSkipVerify': True
+            },
+            'name': 'openshift_prometheus',
+            'orgId': 1,
+            'secureJsonData': {'basicAuthPassword': 'admin'},
+            'type': 'prometheus',
+            'url': 'https://openshift-monitoring.company.com',
+            'user': '',
+            'withCredentials': False
+        }
+        set_module_args({
+            'url': 'https://grafana.example.com',
+            'url_username': 'admin',
+            'url_password': 'admin',
+            'name': 'openshift_prometheus',
+            'ds_type': 'prometheus',
+            'ds_url': 'https://openshift-monitoring.company.com',
+            'access': 'proxy',
+            'basic_auth_user': 'admin',
+            'basic_auth_password': 'admin',
+            'tls_skip_verify': 'true',
+        })
+        module = grafana_datasource.setup_module_object()
+        payload = grafana_datasource.get_datasource_payload(module.params)
+        self.assertEqual(payload, expected_payload)
+
+    def test_payload_influxdb(self):
+        expected_payload = {
+            'access': 'proxy',
+            'basicAuth': False,
+            'database': 'telegraf',
+            'isDefault': False,
+            'jsonData': {
+                'timeInterval': '>10s',
+                'tlsAuth': False,
+                'tlsAuthWithCACert': True
+            },
+            'name': 'datasource-influxdb',
+            'orgId': 1,
+            'secureJsonData': {
+                'tlsCACert': '/etc/ssl/certs/ca.pem'
+            },
+            'type': 'influxdb',
+            'url': 'https://influx.company.com:8086',
+            'user': '',
+            'withCredentials': False
+        }
+        set_module_args({
+            'url': 'https://grafana.example.com',
+            'url_username': 'admin',
+            'url_password': 'admin',
+            'name': 'datasource-influxdb',
+            'ds_type': 'influxdb',
+            'ds_url': 'https://influx.company.com:8086',
+            'database': 'telegraf',
+            'time_interval': '>10s',
+            'tls_ca_cert': '/etc/ssl/certs/ca.pem'
+        })
+        module = grafana_datasource.setup_module_object()
+        payload = grafana_datasource.get_datasource_payload(module.params)
+        self.assertEqual(payload, expected_payload)
+
+    def test_payload_elastic(self):
+        expected_payload = {
+            'access': 'proxy',
+            'basicAuth': True,
+            'basicAuthUser': 'grafana',
+            'database': '[logstash_]YYYY.MM.DD',
+            'isDefault': False,
+            'jsonData': {
+                'esVersion': 56,
+                'interval': 'Daily',
+                'maxConcurrentShardRequests': 42,
+                'timeField': '@timestamp',
+                'timeInterval': '1m',
+                'tlsAuth': False,
+                'tlsAuthWithCACert': True
+            },
+            'name': 'datasource-elastic',
+            'orgId': 1,
+            'secureJsonData': {
+                'basicAuthPassword': 'grafana',
+                'tlsCACert': '/etc/ssl/certs/ca.pem'
+            },
+            'type': 'elasticsearch',
+            'url': 'https://elastic.company.com:9200',
+            'user': '',
+            'withCredentials': False
+        }
+        set_module_args({
+            'url': 'https://grafana.example.com',
+            'url_username': 'admin',
+            'url_password': 'admin',
+            'name': 'datasource-elastic',
+            'ds_type': 'elasticsearch',
+            'ds_url': 'https://elastic.company.com:9200',
+            'database': '[logstash_]YYYY.MM.DD',
+            'basic_auth_user': 'grafana',
+            'basic_auth_password': 'grafana',
+            'time_field': '@timestamp',
+            'time_interval': '1m',
+            'interval': 'Daily',
+            'es_version': 56,
+            'max_concurrent_shard_requests': 42,
+            'tls_ca_cert': '/etc/ssl/certs/ca.pem'
+        })
+        module = grafana_datasource.setup_module_object()
+        payload = grafana_datasource.get_datasource_payload(module.params)
+        self.assertEqual(payload, expected_payload)


### PR DESCRIPTION
Adding these tests aims at being capable to detect drifts in the sent
requests when one is refoactoring the module.

##### SUMMARY

Add unit tests to cover `grafana_datasource` module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
grafana_datasource.py

##### ADDITIONAL INFORMATION

Adding these tests aims at being able to split `get_datasource_payload` function is several functions (one per datasource type) to ease readability and maintenance.
