### PR TITLE
test: update GitHub workflows

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -28,7 +28,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
 
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color
+        run: ansible-test sanity --docker -v --color --coverage
         working-directory: ./ansible_collections/community/grafana
       
       - name: Generate coverage report
@@ -97,7 +97,7 @@ jobs:
         run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
 
       - name: Run integration tests on Python ${{ matrix.python_version }}
-        run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff
+        run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff --coverage
         working-directory: ./ansible_collections/community/grafana
       
       - name: Generate coverage report

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -17,7 +17,7 @@ jobs:
           path: ansible_collections/community/grafana
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python_version }}
 
@@ -40,7 +40,7 @@ jobs:
           path: ansible_collections/community/grafana
 
       - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python_version }}
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color
         working-directory: ./ansible_collections/community/grafana
+      
+      - name: Generate coverage report
+        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+        working-directory: ./ansible_collections/community/grafana
+
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false
 
   units:
     runs-on: ubuntu-latest
@@ -88,3 +96,11 @@ jobs:
       - name: Run integration tests on Python ${{ matrix.python_version }}
         run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff
         working-directory: ./ansible_collections/community/grafana
+      
+      - name: Generate coverage report
+        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+        working-directory: ./ansible_collections/community/grafana
+
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   sanity:

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,14 +79,11 @@ jobs:
         ansible_version: ["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "devel"]
         python_version: ["3.8"]
     container:
-      image: python:${{ matrix.python_version }}-alpine
+      image: python:${{ matrix.python_version }}
     services:
       grafana:
         image: grafana/grafana:${{ matrix.grafana_version }}
     steps:
-
-      - name: Install requirements on alpine
-        run: apk add bash git gcc python3-dev libc-dev libffi-dev openssl-dev rust cargo openssh-keygen
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
 

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           path: ansible_collections/community/grafana
 
@@ -26,6 +26,7 @@ jobs:
 
       - name: Run sanity tests
         run: ansible-test sanity --docker -v --color
+        working-directory: ./ansible_collections/community/grafana
 
   units:
     runs-on: ubuntu-latest
@@ -35,7 +36,7 @@ jobs:
         ansible_version: ["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "devel"]
     steps:
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           path: ansible_collections/community/grafana
 
@@ -49,9 +50,11 @@ jobs:
 
       - name: Run unit tests
         run: ansible-test units --docker -v --color --python ${{ matrix.python_version }} --coverage
+        working-directory: ./ansible_collections/community/grafana
 
       - name: Generate coverage report.
         run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+        working-directory: ./ansible_collections/community/grafana
 
       - uses: codecov/codecov-action@v2
         with:
@@ -75,7 +78,7 @@ jobs:
         run: apk add bash git gcc python3-dev libc-dev libffi-dev openssl-dev rust cargo openssh-keygen
 
       - name: Check out code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
           path: ansible_collections/community/grafana
 
@@ -84,3 +87,4 @@ jobs:
 
       - name: Run integration tests on Python ${{ matrix.python_version }}
         run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff
+        working-directory: ./ansible_collections/community/grafana

--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase')
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Automatic Rebase
       uses: cirrus-actions/rebase@1.2
       env:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Grafana Collection for Ansible
 
 ![](https://github.com/ansible-collections/grafana/workflows/CI/badge.svg?branch=master)
-[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/grafana)](https://codecov.io/gh/ansible-collections/community.grafana)
+[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.grafana)](https://codecov.io/gh/ansible-collections/community.grafana)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The `tests` directory contains configuration for running sanity and integration 
 You can run the collection's test suites with the commands:
 
     ansible-test sanity --docker -v --color
+    ansible-test units --docker -v --color
     ansible-test integration --docker -v --color
 
 ## Publishing New Versions

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -68,7 +68,8 @@ options:
     type: str
     choices: ["present", "absent"]
 notes:
-- Unlike other modules from the collection, this module does not support `grafana_api_key` authentication type. The Grafana API endpoint for users management requires basic auth and admin privileges.
+- Unlike other modules from the collection, this module does not support `grafana_api_key` authentication type. The Grafana API endpoint for users management
+  requires basic auth and admin privileges.
 extends_documentation_fragment:
 - community.grafana.basic_auth
 '''


### PR DESCRIPTION
Update and improve the Github workflows:
- upgrade versions of  `actions/checkout`, `actions/setup-python` and `codecov/codecov-action` (codecov-action@v1 is [deprecated](https://github.com/codecov/codecov-action/blob/master/CHANGELOG.md#200))
- add coverage for sanity and integration tests
- fix an error reported by sanity tests (line too long)
- fix the codecov badge URL (currently links to the old repository: `ansible-collections/grafana`)
- run workflow on push to main branch (so that the coverage is generated and displayed for the default branch in codecov)

@gundalow @rrey @seuf it seems that codecov overview displays coverage for the `master` branch (that no longer exists) and not `main`. Can one of you look at the [codecov settings](https://app.codecov.io/gh/ansible-collections/community.grafana/settings) and make sure that the default branch is `main` ?
