### PR TITLE
ci: add configuration for codecov file viewer

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
+          flags: sanity
 
   units:
     runs-on: ubuntu-latest
@@ -70,6 +71,7 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
+          flags: units
 
   integration:
     runs-on: ubuntu-latest
@@ -104,3 +106,4 @@ jobs:
       - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
+          flags: integration

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,5 @@ coverage:
   precision: 2
   round: down
   range: "70...100"
+fixes:
+   - "/ansible_collections/community/grafana/::"


### PR DESCRIPTION
##### SUMMARY

Add configuration for codecov file viewer.

##### ADDITIONAL INFORMATION

- Set `fixes` in `codecov.yml` so that codecov can get the source code. Fixes this [issue](https://app.codecov.io/gh/ansible-collections/community.grafana/blob/911180307966b81194b98cd5688f67a7bb5bd38c/ansible_collections/community/grafana/plugins/modules/grafana_dashboard.py) : "There was a problem getting the source code from your provider. Unable to show line by line coverage.".  
- Added flags to differentiate the type of tests.
