### PR TITLE
fix(grafana_datasource): remove requirement for `ds_type` and `ds_url`

### DIFF
--- a/changelogs/fragments/170_remove_requirement_ds_type_ds_url.yml
+++ b/changelogs/fragments/170_remove_requirement_ds_type_ds_url.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Remove requirement for `ds_type` and `ds_url` parameters when deleting a datasource

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -25,7 +25,7 @@ options:
   ds_type:
     description:
     - The type of the datasource.
-    required: true
+    - Required when C(state=present).
     choices:
     - graphite
     - prometheus
@@ -44,7 +44,7 @@ options:
   ds_url:
     description:
     - The URL of the datasource.
-    required: true
+    - Required when C(state=present).
     type: str
   access:
     description:
@@ -673,8 +673,8 @@ def main():
                               'camptocamp-prometheus-alertmanager-datasource',
                               'sni-thruk-datasource',
                               'redis-datasource',
-                              'loki'], required=True),
-        ds_url=dict(required=True, type='str'),
+                              'loki']),
+        ds_url=dict(type='str'),
         access=dict(default='proxy', choices=['proxy', 'direct']),
         database=dict(type='str', default=""),
         user=dict(default='', type='str'),
@@ -722,6 +722,7 @@ def main():
         required_together=[['url_username', 'url_password', 'org_id'], ['tls_client_cert', 'tls_client_key']],
         mutually_exclusive=[['url_username', 'grafana_api_key'], ['tls_ca_cert', 'tls_skip_verify']],
         required_if=[
+            ['state', 'present', ['ds_type', 'ds_url']],
             ['ds_type', 'opentsdb', ['tsdb_version', 'tsdb_resolution']],
             ['ds_type', 'influxdb', ['database']],
             ['ds_type', 'elasticsearch', ['database', 'es_version', 'time_field', 'interval']],

--- a/tests/integration/targets/grafana_datasource/tasks/cloudwatch.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/cloudwatch.yml
@@ -84,14 +84,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password}}"
-    org_id: '1'
-    ds_type: cloudwatch
-    ds_url: http://monitoring.us-west-1.amazonaws.com
-    aws_auth_type: keys
-    aws_default_region: us-west-1
-    aws_access_key: speakFriendAndEnter
-    aws_secret_key: mel10n
-    aws_custom_metrics_namespaces: n1,n2
     state: absent
 
 - debug:
@@ -109,14 +101,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password}}"
-    org_id: '1'
-    ds_type: cloudwatch
-    ds_url: http://monitoring.us-west-1.amazonaws.com
-    aws_auth_type: keys
-    aws_default_region: us-west-1
-    aws_access_key: speakFriendAndEnter
-    aws_secret_key: mel10n
-    aws_custom_metrics_namespaces: n1,n2
     state: absent
 
 - debug:

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -245,18 +245,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: elasticsearch
-    ds_url: https://elastic.company.com:9200
-    database: '[logstash_]YYYY.MM.DD'
-    basic_auth_user: grafana
-    basic_auth_password: '******'
-    time_field: '@timestamp'
-    time_interval: 1m
-    interval: Daily
-    es_version: 56
-    max_concurrent_shard_requests: 42
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - assert:
@@ -270,18 +258,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: elasticsearch
-    ds_url: https://elastic.company.com:9200
-    database: '[logstash_]YYYY.MM.DD'
-    basic_auth_user: grafana
-    basic_auth_password: '******'
-    time_field: '@timestamp'
-    time_interval: 1m
-    interval: Daily
-    es_version: 56
-    max_concurrent_shard_requests: 42
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - assert:

--- a/tests/integration/targets/grafana_datasource/tasks/errors.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/errors.yml
@@ -1,0 +1,18 @@
+---
+- name: Create datasource without `ds_type` and `ds_url` (expect failure)
+  register: result
+  grafana_datasource:
+    name: datasource-postgres
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+  ignore_errors: true
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - not result.changed
+    - result.failed
+    - "result.msg == 'state is present but all of the following are missing: ds_type, ds_url'"

--- a/tests/integration/targets/grafana_datasource/tasks/influx.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/influx.yml
@@ -62,12 +62,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: influxdb
-    ds_url: https://influx.company.com:8086
-    database: telegraf
-    time_interval: '>10s'
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - debug:
@@ -84,12 +78,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: influxdb
-    ds_url: https://influx.company.com:8086
-    database: telegraf
-    time_interval: '>10s'
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - debug:

--- a/tests/integration/targets/grafana_datasource/tasks/loki.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/loki.yml
@@ -55,9 +55,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password}}"
-    org_id: '1'
-    ds_type: loki
-    ds_url: https://loki.company.com:3100
     state: absent
 
 - debug:
@@ -75,9 +72,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password}}"
-    org_id: '1'
-    ds_type: loki
-    ds_url: https://loki.company.com:3100
     state: absent
 
 - debug:

--- a/tests/integration/targets/grafana_datasource/tasks/main.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 
 - block:
+  - include: errors.yml
   - include: elastic.yml
   - include: influx.yml
   - include: postgres.yml

--- a/tests/integration/targets/grafana_datasource/tasks/postgres.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/postgres.yml
@@ -67,13 +67,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: postgres
-    ds_url: postgres.company.com:5432
-    database: db
-    user: postgres
-    password: iampgroot
-    sslmode: verify-full
     state: absent
 
 - debug:
@@ -90,13 +83,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: postgres
-    ds_url: postgres.company.com:5432
-    database: db
-    user: postgres
-    password: iampgroot
-    sslmode: verify-full
     state: absent
 
 - debug:

--- a/tests/integration/targets/grafana_datasource/tasks/redis.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/redis.yml
@@ -81,9 +81,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: redis-datasource
-    ds_url: https://redis.company.com:6379
     state: absent
 
 - assert:
@@ -97,9 +94,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: redis-datasource
-    ds_url: https://redis.company.com:6379
     state: absent
 
 - assert:

--- a/tests/integration/targets/grafana_datasource/tasks/thruk.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/thruk.yml
@@ -55,11 +55,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: "1"
-    ds_type: sni-thruk-datasource
-    ds_url: "https://thruk.company.com/sitename/thruk"
-    tls_skip_verify: yes
-    validate_certs: no
     state: absent
 
 - debug:
@@ -76,11 +71,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: "1"
-    ds_type: sni-thruk-datasource
-    ds_url: "https://thruk.company.com/sitename/thruk"
-    tls_skip_verify: yes
-    validate_certs: no
     state: absent
 
 - assert:

--- a/tests/integration/targets/grafana_datasource/tasks/zabbix.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/zabbix.yml
@@ -94,12 +94,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: alexanderzobnin-zabbix-datasource
-    ds_url: https://zabbix.example.com
-    zabbix_user: grafana
-    zabbix_password: '******'
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - assert:
@@ -113,12 +107,6 @@
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
-    ds_type: alexanderzobnin-zabbix-datasource
-    ds_url: https://zabbix.example.com
-    zabbix_user: grafana
-    zabbix_password: '******'
-    tls_ca_cert: /etc/ssl/certs/ca.pem
     state: absent
 
 - assert:


### PR DESCRIPTION
##### SUMMARY

Fixes #170.

Require `ds_type` and `ds_url` only when creating or updating a datasource.


##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
grafana_datasource

##### ADDITIONAL INFORMATION

- Added an integration test for missing parameters (`ds_type` and `ds_url`) when creating or updating a datasource
- Removed useless parameters when deleting datasources in integration tests ([only the name is used for deleting](https://github.com/ansible-collections/community.grafana/blob/911180307966b81194b98cd5688f67a7bb5bd38c/plugins/modules/grafana_datasource.py#L645))
