### PR TITLE
feat: add support for module group defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,45 @@ You can either call modules by their Fully Qualified Collection Namespace (FQCN)
 
 For documentation on how to use individual modules and other content included in this collection, please see the links in the 'Included content' section earlier in this README.
 
+### Using module group defaults
+
+In your playbooks, you can set [module defaults](https://github.com/ansible/ansible/blob/v2.12.3/docs/docsite/rst/user_guide/playbooks_module_defaults.rst#module-defaults-groups) for the `community.grafana.grafana` group to avoid repeating the same parameters (e.g., `grafana_url`, `grafana_user`, `grafana_password`) in your tasks: 
+
+
+```yaml
+- hosts: localhost
+  gather_facts: false
+  connection: local
+
+  collections:
+    - community.grafana
+  
+  module_defaults:
+    group/community.grafana.grafana:
+      grafana_url: "https://grafana.company.com"
+      grafana_user: "admin"
+      grafana_password: "xxxxxx"
+
+  tasks:
+    - name: Ensure Influxdb datasource exists.
+      grafana_datasource:
+        name: "datasource-influxdb"
+        org_id: "1"
+        ds_type: "influxdb"
+        ds_url: "https://influx.company.com:8086"
+        database: "telegraf"
+        time_interval: ">10s"
+        tls_ca_cert: "/etc/ssl/certs/ca.pem"
+    
+    - name: Create or update a Grafana user
+      grafana_user:
+        name: "Bruce Wayne"
+        email: "batman@gotham.city"
+        login: "batman"
+        password: "robin"
+        is_admin: true
+```
+
 ## Testing and Development
 
 If you want to develop new content for this collection or improve what's already here, the easiest way to work on the collection is to clone it into one of the configured [`COLLECTIONS_PATHS`](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#collections-paths), and work on it there.

--- a/changelogs/fragments/136_add_grafana_action_groups.yml
+++ b/changelogs/fragments/136_add_grafana_action_groups.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- add `grafana` action group in `meta/runtime.yml` to support for module group defaults

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,12 @@
 ---
 requires_ansible: '>=2.9.0'
+action_groups:
+  grafana:
+  - grafana_dashboard
+  - grafana_datasource
+  - grafana_folder
+  - grafana_notification_channel
+  - grafana_organization
+  - grafana_plugin
+  - grafana_team
+  - grafana_user

--- a/plugins/callback/grafana_annotations.py
+++ b/plugins/callback/grafana_annotations.py
@@ -103,6 +103,7 @@ DOCUMENTATION = '''
             key: grafana_panel_ids
         default: []
         type: list
+        elements: integer
 '''
 
 import json

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -67,7 +67,7 @@ options:
   dashboard_revision:
     description:
       - Revision of the public grafana dashboard to import
-    default: 1
+    default: '1'
     version_added: "1.0.0"
     type: str
   commit_message:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add `grafana` action group to support module group defaults.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #136 


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### ADDITIONAL INFORMATION

Works with [ansible-core 2.12.0 and later](https://github.com/ansible/ansible/pull/74039) ([doc](https://github.com/ansible/ansible/blob/v2.12.3/docs/docsite/rst/user_guide/playbooks_module_defaults.rst#module-defaults-groups)):
```yml
- hosts: 'localhost'
  collections:
    - community.grafana
  module_defaults:
    group/community.grafana.grafana:
      grafana_url: "http://localhost:3000"
      grafana_user: "admin"
      grafana_password: "admin"

  tasks:
    - name: add datasource
      grafana_datasource:
        name: "datasource-prometheus"
        ds_type: "prometheus"
        ds_url: "http://prometheus:9090"
    
    - name: add dashboard
      grafana_dashboard:
        commit_message: "Updated by ansible"
        dashboard_id: "6098"
        dashboard_revision: "1"
```
