### PR TITLE
Fix KeyError fatal error when using `url` option instead of `grafana_url`

### DIFF
--- a/changelogs/fragments/239_keyerror_grafana_url.yml
+++ b/changelogs/fragments/239_keyerror_grafana_url.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- Fix a bug that causes a fatal error when using `url` parameter in
+  `grafana_dashboard` and `grafana_notification_channel` modules.

--- a/plugins/modules/grafana_notification_channel.py
+++ b/plugins/modules/grafana_notification_channel.py
@@ -627,7 +627,7 @@ class GrafanaNotificationChannelInterface(object):
                                       (org_id, info))
 
     def grafana_create_notification_channel(self, data, payload):
-        r, info = fetch_url(self._module, '%s/api/alert-notifications' % data['grafana_url'],
+        r, info = fetch_url(self._module, '%s/api/alert-notifications' % data['url'],
                             data=json.dumps(payload), headers=self.headers, method='POST')
         if info['status'] == 200:
             return {
@@ -640,7 +640,7 @@ class GrafanaNotificationChannelInterface(object):
 
     def grafana_update_notification_channel(self, data, payload, before):
         r, info = fetch_url(self._module, '%s/api/alert-notifications/uid/%s' %
-                            (data['grafana_url'], data['uid']),
+                            (data['url'], data['uid']),
                             data=json.dumps(payload), headers=self.headers, method='PUT')
         if info['status'] == 200:
             del before['created']
@@ -672,7 +672,7 @@ class GrafanaNotificationChannelInterface(object):
     def grafana_create_or_update_notification_channel(self, data):
         payload = grafana_notification_channel_payload(data)
         r, info = fetch_url(self._module, '%s/api/alert-notifications/uid/%s' %
-                            (data['grafana_url'], data['uid']), headers=self.headers)
+                            (data['url'], data['uid']), headers=self.headers)
         if info['status'] == 200:
             before = json.loads(to_text(r.read()))
             return self.grafana_update_notification_channel(data, payload, before)
@@ -684,7 +684,7 @@ class GrafanaNotificationChannelInterface(object):
 
     def grafana_delete_notification_channel(self, data):
         r, info = fetch_url(self._module, '%s/api/alert-notifications/uid/%s' %
-                            (data['grafana_url'], data['uid']),
+                            (data['url'], data['uid']),
                             headers=self.headers, method='DELETE')
         if info['status'] == 200:
             return {
@@ -828,7 +828,7 @@ def main():
         ]
     )
 
-    module.params["grafana_url"] = clean_url(module.params["grafana_url"])
+    module.params["url"] = clean_url(module.params["url"])
     alert_channel_iface = GrafanaNotificationChannelInterface(module)
 
     if module.params['state'] == 'present':


### PR DESCRIPTION
##### SUMMARY

Fixes #239.

Use `url` (option's name) instead of `grafana_url` (option's alias) when accessing modules params in `grafana_dashboard` and `grafana_notification_channel`.  

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
grafana_dashboard
grafana_notification_channel

##### ADDITIONAL INFORMATION

Module params values should be accessed by using the option's name and not an alias.  

##### New result with these changes (see "steps to reproduce" and "actual results" from #239):

```
TASK [Create dashboard] *************************************************************************************************************************************************************************************
changed: [localhost]

TASK [Create notification channel] **************************************************************************************************************************************************************************
changed: [localhost]
```