### PR TITLE
test: Support Grafana 9 in integration tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        grafana_version: ["8.1.8",  "8.2.7", "8.3.3"]
+        grafana_version: ["8.1.8",  "8.2.7", "8.3.3", "9.0.0"]
         ansible_version: ["stable-2.9", "stable-2.10", "stable-2.11", "stable-2.12", "stable-2.13", "devel"]
         python_version: ["3.8"]
     container:

--- a/tests/integration/targets/grafana_datasource/tasks/azure.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/azure.yml
@@ -31,7 +31,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-azure'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'grafana-azure-monitor-datasource'
     - result.datasource.url == 'http://example.com'
     - result.datasource.user == ''
@@ -69,7 +69,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-azure'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'grafana-azure-monitor-datasource'
     - result.datasource.url == 'http://example.com'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/cloudwatch.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/cloudwatch.yml
@@ -32,7 +32,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-cloudwatch'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'cloudwatch'
     - result.datasource.url == 'http://monitoring.us-west-1.amazonaws.com'
     - result.datasource.user == ''
@@ -71,7 +71,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-cloudwatch'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'cloudwatch'
     - result.datasource.url == 'http://monitoring.us-west-1.amazonaws.com'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -37,7 +37,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.company.com:9200'
     - result.datasource.user == ''
@@ -83,7 +83,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.company.com:9200'
     - result.datasource.user == ''
@@ -128,7 +128,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.example.com:9200'
     - result.datasource.user == ''
@@ -178,7 +178,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.example.com:9200'
     - result.datasource.user == ''
@@ -229,7 +229,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.example.com:9200'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/influx.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/influx.yml
@@ -49,7 +49,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource-influxdb'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'influxdb'
     - result.datasource.url == 'https://influx.company.com:8086'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/issues.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/issues.yml
@@ -36,7 +36,7 @@
     - not result.datasource.jsonData.tlsAuthWithCACert
     - result.datasource.name == 'datasource/elastic'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'elasticsearch'
     - result.datasource.url == 'https://elastic.company.com:9200'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/loki.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/loki.yml
@@ -42,7 +42,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-loki'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'loki'
     - result.datasource.url == 'https://loki.company.com:3100'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/thruk.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/thruk.yml
@@ -42,7 +42,7 @@
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.name == 'datasource-thruk'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'sni-thruk-datasource'
     - result.datasource.url == 'https://thruk.company.com/sitename/thruk'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_datasource/tasks/zabbix.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/zabbix.yml
@@ -21,7 +21,7 @@
     - result.datasource.jsonData.username == 'grafana'
     - result.datasource.name == 'datasource-zabbix'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'alexanderzobnin-zabbix-datasource'
     - result.datasource.url == 'https://zabbix.company.com'
     - result.datasource.user == ''
@@ -51,7 +51,7 @@
     - result.datasource.jsonData.username == 'grafana'
     - result.datasource.name == 'datasource-zabbix'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'alexanderzobnin-zabbix-datasource'
     - result.datasource.url == 'https://zabbix.company.com'
     - result.datasource.user == ''
@@ -80,7 +80,7 @@
     - result.datasource.jsonData.username == 'grafana'
     - result.datasource.name == 'datasource-zabbix'
     - result.datasource.orgId == 1
-    - result.datasource.password == ''
+    - ('password' not in result.datasource) or (result.datasource.password == '')
     - result.datasource.type == 'alexanderzobnin-zabbix-datasource'
     - result.datasource.url == 'https://zabbix.example.com'
     - result.datasource.user == ''

--- a/tests/integration/targets/grafana_team/tasks/main.yml
+++ b/tests/integration/targets/grafana_team/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Create a Team without members
+- name: Create a Team
   grafana_team:
       url: "{{ grafana_url }}"
       url_username: "{{ grafana_username }}"
@@ -10,13 +10,20 @@
       state: present
   register: result
 
+- set_fact:
+    # From Grafana 9.0.0, the API user automatically becomes a member of the team
+    auto_member: "{{ result.team.memberCount == 1 }}"
+
+- set_fact:
+    expected_members: "{{ auto_member | ternary(['********@localhost'], []) }}"
+
 - assert:
     that:
       - "result.changed == true"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 0"
-      - "result.team.members == []"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
 
 - name: Check idempotency on team creation
   grafana_team:
@@ -32,9 +39,9 @@
     that:
       - "result.changed == false"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 0"
-      - "result.team.members == []"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
 
 - name: Check a team can be deleted
   grafana_team:
@@ -82,13 +89,16 @@
       state: present
   register: result
 
+- set_fact:
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john.doe@example.com'], ['jane.doe@example.com', 'john.doe@example.com']) }}"
+
 - assert:
     that:
       - "result.changed == true"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 2"
-      - "result.team.members == ['jane.doe@example.com', 'john.doe@example.com']"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
 
 - name: Ensure a Team exists with member not enforced
   grafana_team:
@@ -106,9 +116,13 @@
     that:
       - "result.changed == false"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 2"
-      - "result.team.members == ['jane.doe@example.com', 'john.doe@example.com']"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
+
+- set_fact:
+    enforced_members: "{{ auto_member | ternary(['admin@localhost', 'john.doe@example.com'], ['john.doe@example.com']) }}"
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'john.doe@example.com'], ['john.doe@example.com']) }}"
 
 - name: Ensure a Team exists with member enforced
   grafana_team:
@@ -117,8 +131,7 @@
       url_password: "{{ grafana_password }}"
       name: "grafana_working_group"
       email: "foo.bar@example.com"
-      members:
-          - "john.doe@example.com"
+      members: "{{ enforced_members }}"
       enforce_members: true
       state: present
   register: result
@@ -127,9 +140,9 @@
     that:
       - "result.changed == true"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 1"
-      - "result.team.members == ['john.doe@example.com']"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
 
 - name: Ensure a Team exists with members omitted
   grafana_team:
@@ -145,9 +158,9 @@
     that:
       - "result.changed == false"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 1"
-      - "result.team.members == ['john.doe@example.com']"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"
 
 - name: Add new member to existing Team
   grafana_team:
@@ -162,10 +175,13 @@
       state: present
   register: result
 
+- set_fact:
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john.doe@example.com'], ['jane.doe@example.com', 'john.doe@example.com']) }}"
+
 - assert:
     that:
       - "result.changed == true"
       - "result.team.name == 'grafana_working_group'"
-      - "result.team.memberCount == 2"
-      - "result.team.members == ['jane.doe@example.com', 'john.doe@example.com']"
       - "result.team.email == 'foo.bar@example.com'"
+      - "result.team.memberCount == (expected_members|length)"
+      - "result.team.members == expected_members"


### PR DESCRIPTION
Support Grafana 9 in integration tests.

Notes specific to behavior observed in Grafana 9.0.0:
* For datasources, Grafana does not return the `password` field anymore.
* For teams, Grafana now automatically adds the user creating the team
as a member. Also, Grafana does not allow removing the last admin user
from a team.
