### PR TITLE
fix(changelog-fragment): do not comment or approve from actions

### DIFF
--- a/.github/workflows/fragment.yml
+++ b/.github/workflows/fragment.yml
@@ -11,7 +11,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Automatic Rebase
+    - name: Check that changelog fragment exists
       run: ./hacking/check_fragment.sh
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/hacking/check_fragment.sh
+++ b/hacking/check_fragment.sh
@@ -1,23 +1,17 @@
 #!/bin/bash
 
-function comment() {
-    echo "No fragment detected"
-    if [ -n "$PR_NUMBER" ]; then
-        gh pr review "$PR_NUMBER" -r -F "$(git rev-parse --show-toplevel)/hacking/NEED_FRAGMENT"
-    fi
+function fail() {
+    cat << EOF
+    Dear contributor,
+
+    Thank you for you Pull Request !
+    To ease the work of maintainers you need to add a [changelog fragment](https://docs.ansible.com/ansible/latest/community/development_process.html#creating-a-changelog-fragment) in you PR.
+
+    It will help your change be released faster !
+    Thank you !
+EOF
     exit 1
 }
 
-function approve() {
-    if [ -n "$PR_NUMBER" ]; then
-        gh pr review "$PR_NUMBER" -a
-    fi
-}
-
 FRAGMENTS=$(git fetch && git diff --name-only --diff-filter=ACMRT origin/main..HEAD | grep "changelogs/fragments")
-
-if [ -z "$FRAGMENTS" ]; then
-    comment
-else
-    approve
-fi
+[ -z "$FRAGMENTS" ] && fail


### PR DESCRIPTION
Github actions permissions from forks will not allow the github token
to perform comments of approves on the PR, breaking the initial idea.

Updating the workflow to simply fail if the changelog fragment is
present and display the error message in the workflow logs.
