### PR TITLE
url encode user email/login

### DIFF
--- a/changelogs/fragments/265-url-encode-user.yml
+++ b/changelogs/fragments/265-url-encode-user.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Ensure user email/login is url encoded when searching for the user (#264)

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -276,7 +276,7 @@ class GrafanaTeamInterface(object):
         self._send_request(url, headers=self.headers, method="DELETE")
 
     def get_user_id_from_mail(self, email):
-        url = "/api/users/lookup?loginOrEmail={email}".format(email=email)
+        url = "/api/users/lookup?loginOrEmail={email}".format(email=quote(email))
         user = self._send_request(url, headers=self.headers, method="GET")
         if user is None:
             self._module.fail_json(failed=True, msg="User '%s' does not exists" % email)

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -159,6 +159,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
+from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 
@@ -203,7 +204,7 @@ class GrafanaUserInterface(object):
 
     def get_user_from_login(self, login):
         # https://grafana.com/docs/grafana/latest/http_api/user/#get-single-user-by-usernamelogin-or-email
-        url = "/api/users/lookup?loginOrEmail={login}".format(login=login)
+        url = "/api/users/lookup?loginOrEmail={login}".format(login=quote(login))
         return self._send_request(url, headers=self.headers, method="GET")
 
     def update_user(self, user_id, email, name, login):


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.grafana/issues/264

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_team

##### ADDITIONAL INFORMATION
Currently searching for users with + in the email address will fail, as the character won't be properly encoded `/api/users/lookup?loginOrEmail=myaccount+grafana@gmail.com`

