### PR TITLE
Replace GHA boilerplate with the use of an Action

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -8,70 +8,43 @@ on:
 jobs:
   sanity:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Sanity (Ⓐ$${{ matrix.ansible }})
     strategy:
       matrix:
-        python_version: ["3.8"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
+        ansible:
+          - stable-2.11
+          - stable-2.12
+          - stable-2.13
+          - devel
     steps:
-
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Perform testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          path: ansible_collections/community/grafana
-
-      - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python_version }}
-
-      - name: Install ansible
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-
-      - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color --coverage
-        working-directory: ./ansible_collections/community/grafana
-      
-      - name: Generate coverage report
-        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/community/grafana
-
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: false
-          flags: sanity
+          ansible-core-version: ${{ matrix.ansible }}
+          python-version: 3.8
+          target-python-version: 3.8
+          testing-type: sanity
 
   units:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: Units (Ⓐ${{ matrix.ansible }})
     strategy:
       matrix:
-        python_version: ["3.8"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
+        ansible:
+          - stable-2.11
+          - stable-2.12
+          - stable-2.13
+          - devel
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Perform testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          path: ansible_collections/community/grafana
-
-      - name: Set up Python ${{ matrix.python_version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python_version }}
-
-      - name: Install ansible
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-
-      - name: Run unit tests
-        run: ansible-test units --docker -v --color --python ${{ matrix.python_version }} --coverage
-        working-directory: ./ansible_collections/community/grafana
-
-      - name: Generate coverage report.
-        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/community/grafana
-
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: false
-          flags: units
+          ansible-core-version: ${{ matrix.ansible }}
+          python-version: 3.8
+          target-python-version: 3.8
+          testing-type: units
 
   integration:
     runs-on: ubuntu-latest
@@ -79,32 +52,19 @@ jobs:
       fail-fast: false
       matrix:
         grafana_version: ["9.0.2", "8.5.6", "7.5.16"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
-        python_version: ["3.8"]
-    container:
-      image: python:${{ matrix.python_version }}
+        ansible: 
+          - stable-2.11
+          - stable-2.12
+          - stable-2.13
+          - devel
     services:
       grafana:
         image: grafana/grafana:${{ matrix.grafana_version }}
     steps:
-
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Perform testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          path: ansible_collections/community/grafana
-
-      - name: Install ansible
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-
-      - name: Run integration tests on Python ${{ matrix.python_version }}
-        run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff --coverage
-        working-directory: ./ansible_collections/community/grafana
-      
-      - name: Generate coverage report
-        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/community/grafana
-
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: false
-          flags: integration
+          ansible-core-version: ${{ matrix.ansible }}
+          python-version: 3.8
+          target-python-version: 3.8
+          testing-type: integration


### PR DESCRIPTION
This patch replaces manually maintained copy-paste of `ansible-test`
invocations with the use of a reusable GitHub Action[1] that wraps
it allowing to only keep the matrix on the project side allowing the
reusable bits to be maintained separately and be shared across the
community.

This has been earlier implemented for the `community.digitalocean`
collection[2] among others.

[1]: https://github.com/ansible-community/ansible-test-gh-action
[2]: https://github.com/ansible-collections/community.digitalocean/pull/144

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
See above.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`.github/workflows/ansible-test.yml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This is also on the way of being included into the default collection skeleton at https://github.com/ansible/ansible/pull/74901/files#diff-096f7bb125bbac5751a11cfa3f7682b8d7c7c8cfffb0feddd10fb78e7346950d.