### PR TITLE
test(team-and-user): add tests with encoded char in login/name

### DIFF
--- a/changelogs/fragments/265-url-encode-user.yml
+++ b/changelogs/fragments/265-url-encode-user.yml
@@ -1,2 +1,4 @@
 bugfixes:
 - Ensure user email/login is url encoded when searching for the user (#264)
+trivial:
+- Add integration tests with encoded characters in name/login (#264)

--- a/tests/integration/targets/grafana_team/tasks/create_user.yml
+++ b/tests/integration/targets/grafana_team/tasks/create_user.yml
@@ -7,7 +7,7 @@
     force_basic_auth: yes
     body:
       name: "John"
-      email: "john.doe@example.com"
+      email: "john+doe@example.com"
       login: "john"
       password: "userpassword"
     body_format: json

--- a/tests/integration/targets/grafana_team/tasks/main.yml
+++ b/tests/integration/targets/grafana_team/tasks/main.yml
@@ -84,13 +84,13 @@
       name: "grafana_working_group"
       email: "foo.bar@example.com"
       members:
-          - "john.doe@example.com"
+          - "john+doe@example.com"
           - "jane.doe@example.com"
       state: present
   register: result
 
 - set_fact:
-    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john.doe@example.com'], ['jane.doe@example.com', 'john.doe@example.com']) }}"
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john+doe@example.com'], ['jane.doe@example.com', 'john+doe@example.com']) }}"
 
 - assert:
     that:
@@ -108,7 +108,7 @@
       name: "grafana_working_group"
       email: "foo.bar@example.com"
       members:
-          - "john.doe@example.com"
+          - "john+doe@example.com"
       state: present
   register: result
 
@@ -121,8 +121,8 @@
       - "result.team.members == expected_members"
 
 - set_fact:
-    enforced_members: "{{ auto_member | ternary(['admin@localhost', 'john.doe@example.com'], ['john.doe@example.com']) }}"
-    expected_members: "{{ auto_member | ternary(['********@localhost', 'john.doe@example.com'], ['john.doe@example.com']) }}"
+    enforced_members: "{{ auto_member | ternary(['admin@localhost', 'john+doe@example.com'], ['john+doe@example.com']) }}"
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'john+doe@example.com'], ['john+doe@example.com']) }}"
 
 - name: Ensure a Team exists with member enforced
   grafana_team:
@@ -170,13 +170,13 @@
       name: "grafana_working_group"
       email: "foo.bar@example.com"
       members:
-          - "john.doe@example.com"
+          - "john+doe@example.com"
           - "jane.doe@example.com"
       state: present
   register: result
 
 - set_fact:
-    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john.doe@example.com'], ['jane.doe@example.com', 'john.doe@example.com']) }}"
+    expected_members: "{{ auto_member | ternary(['********@localhost', 'jane.doe@example.com', 'john+doe@example.com'], ['jane.doe@example.com', 'john+doe@example.com']) }}"
 
 - assert:
     that:

--- a/tests/integration/targets/grafana_user/tasks/main.yml
+++ b/tests/integration/targets/grafana_user/tasks/main.yml
@@ -200,3 +200,38 @@
 - assert:
     that:
       - "result.json.message | lower == 'user not found'"
+
+- name: Create a Grafana user with character encoding
+  grafana_user:
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
+    name: "Bruce Wayne"
+    email: bruce+wayne@gotham.city
+    login: bruce+wayne@gotham.city
+    password: robin
+    state: present
+  register: result
+- assert:
+    that:
+      - "result.changed == true"
+      - "result.user.name == 'Bruce Wayne'"
+      - "result.user.email == 'bruce+wayne@gotham.city'"
+      - "result.user.isGrafanaAdmin == false"
+
+- name: Check idempotency on user creation (password not requiered)
+  grafana_user:
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
+    name: "Bruce Wayne"
+    email: bruce+wayne@gotham.city
+    login: bruce+wayne@gotham.city
+    state: present
+  register: result
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.user.name == 'Bruce Wayne'"
+      - "result.user.email == 'bruce+wayne@gotham.city'"
+      - "result.user.isGrafanaAdmin == false"


### PR DESCRIPTION
CI currently fails on devel because Python 3.8 is no more supported.
The errors on devels can be ignored.

Ref: #264