### PR TITLE
fix(dashboard): specify utf-8 as encoding when opening files

### DIFF
--- a/changelogs/fragments/191.yml
+++ b/changelogs/fragments/191.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - grafana_dashboard, now opens json files with utf-8 encoding (#191)

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -305,7 +305,7 @@ def grafana_create_dashboard(module, data):
         payload = json.loads(r.read())
     else:
         try:
-            with open(data['path'], 'r') as json_file:
+            with open(data['path'], 'r', encoding="utf-8") as json_file:
                 payload = json.load(json_file)
         except Exception as e:
             raise GrafanaAPIException("Can't load json file %s" % to_native(e))
@@ -469,7 +469,7 @@ def grafana_export_dashboard(module, data):
 
     if dashboard_exists is True:
         try:
-            with open(data['path'], 'w') as f:
+            with open(data['path'], 'w', encoding="utf-8") as f:
                 f.write(json.dumps(dashboard, indent=2))
         except Exception as e:
             raise GrafanaExportException("Can't write json file : %s" % to_native(e))


### PR DESCRIPTION
##### SUMMARY

No method of reproduction was found/provided for #191, as a prevention
measure this patch specifies the encoding to use when opening a file to
avoid the open function to auto determine the preferred encoding based
on the locale.

Closes: #191

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`grafana_dashboard`