### PR TITLE
Add support for more elasticsearch version as datasource

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        grafana_version: ["9.1.0", "8.5.10", "7.5.16"]
+        grafana_version: ["9.0.7", "8.5.10", "7.5.16"]
         ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
         python_version: ["3.8", "3.9"]
         exclude:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Click on the name of a plugin or module to view that content's documentation:
 We aim at keeping the last 3 Major versions of Grafana tested.
 This collection is currently testing the modules against following versions of Grafana:
 ```
-grafana_version: ["9.1.0", "8.5.10", "7.5.16"]
+grafana_version: ["9.0.7", "8.5.10", "7.5.16"]
 ```
 
 ## Installation and Usage

--- a/changelogs/fragments/fix-263.yaml
+++ b/changelogs/fragments/fix-263.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add support for more elasticsearch version as datasource (#263)

--- a/tests/integration/targets/grafana_datasource/tasks/elastic.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/elastic.yml
@@ -1,7 +1,8 @@
-- name: Create elasticsearch datasource
+---
+- name: Create elasticsearch datasource with legacy elasticsearch format
   register: result
   grafana_datasource:
-    name: "datasource/elastic"
+    name: "datasource/elasticLegacy"
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
@@ -30,6 +31,52 @@
     - result.datasource.database == '[logstash_]YYYY.MM.DD'
     - not result.datasource.isDefault
     - result.datasource.jsonData.esVersion == 56
+    - result.datasource.jsonData.interval == 'Daily'
+    - result.datasource.jsonData.maxConcurrentShardRequests == 42
+    - result.datasource.jsonData.timeField == '@timestamp'
+    - not result.datasource.jsonData.tlsAuth
+    - result.datasource.jsonData.tlsAuthWithCACert
+    - result.datasource.name == 'datasource/elasticLegacy'
+    - result.datasource.orgId == 1
+    - ('password' not in result.datasource) or (result.datasource.password == '')
+    - result.datasource.type == 'elasticsearch'
+    - result.datasource.url == 'https://elastic.company.com:9200'
+    - result.datasource.user == ''
+    - not result.datasource.withCredentials
+    - "result.msg == 'Datasource datasource/elasticLegacy created'"
+
+- name: Create elasticsearch datasource with new elsaticsearch version format
+  register: result
+  grafana_datasource:
+    name: "datasource/elastic"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: elasticsearch
+    ds_url: https://elastic.company.com:9200
+    database: '[logstash_]YYYY.MM.DD'
+    basic_auth_user: grafana
+    basic_auth_password: '******'
+    time_field: '@timestamp'
+    time_interval: 1m
+    interval: Daily
+    es_version: "7.10+"
+    max_concurrent_shard_requests: 42
+    tls_ca_cert: /etc/ssl/certs/ca.pem
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - result.datasource.basicAuth
+    - result.datasource.basicAuthUser == 'grafana'
+    - result.datasource.access == 'proxy'
+    - result.datasource.database == '[logstash_]YYYY.MM.DD'
+    - not result.datasource.isDefault
+    - result.datasource.jsonData.esVersion == "7.10.0"
     - result.datasource.jsonData.interval == 'Daily'
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
@@ -60,7 +107,7 @@
     time_field: '@timestamp'
     time_interval: 1m
     interval: Daily
-    es_version: 56
+    es_version: "7.10+"
     max_concurrent_shard_requests: 42
     tls_ca_cert: /etc/ssl/certs/ca.pem
 
@@ -75,7 +122,7 @@
     - result.datasource.access == 'proxy'
     - result.datasource.database == '[logstash_]YYYY.MM.DD'
     - not result.datasource.isDefault
-    - result.datasource.jsonData.esVersion == 56
+    - result.datasource.jsonData.esVersion == '7.10.0'
     - result.datasource.jsonData.interval == 'Daily'
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
@@ -105,7 +152,7 @@
     time_field: '@timestamp'
     time_interval: 1m
     interval: Daily
-    es_version: 56
+    es_version: "7.10+"
     max_concurrent_shard_requests: 42
     tls_ca_cert: /etc/ssl/certs/ca.pem
 
@@ -120,7 +167,7 @@
     - result.datasource.access == 'proxy'
     - result.datasource.database == '[logstash_]YYYY.MM.DD'
     - not result.datasource.isDefault
-    - result.datasource.jsonData.esVersion == 56
+    - result.datasource.jsonData.esVersion == '7.10.0'
     - result.datasource.jsonData.interval == 'Daily'
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
@@ -150,7 +197,7 @@
     time_field: '@timestamp'
     time_interval: 1m
     interval: Daily
-    es_version: 56
+    es_version: "7.10+"
     max_concurrent_shard_requests: 42
     tls_ca_cert: /etc/ssl/certs/ca.pem
     enforce_secure_data: false
@@ -170,7 +217,7 @@
     - result.datasource.access == 'proxy'
     - result.datasource.database == '[logstash_]YYYY.MM.DD'
     - not result.datasource.isDefault
-    - result.datasource.jsonData.esVersion == 56
+    - result.datasource.jsonData.esVersion == '7.10.0'
     - result.datasource.jsonData.interval == 'Daily'
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'
@@ -201,7 +248,7 @@
     time_field: '@timestamp'
     time_interval: 1m
     interval: Daily
-    es_version: 56
+    es_version: "7.10+"
     max_concurrent_shard_requests: 42
     tls_ca_cert: /etc/ssl/certs/ca.pem
     enforce_secure_data: true
@@ -221,7 +268,7 @@
     - result.datasource.access == 'proxy'
     - result.datasource.database == '[logstash_]YYYY.MM.DD'
     - not result.datasource.isDefault
-    - result.datasource.jsonData.esVersion == 56
+    - result.datasource.jsonData.esVersion == '7.10.0'
     - result.datasource.jsonData.interval == 'Daily'
     - result.datasource.jsonData.maxConcurrentShardRequests == 42
     - result.datasource.jsonData.timeField == '@timestamp'

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,4 @@
+plugins/modules/grafana_dashboard.py validate-modules:invalid-argument-name
+tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py pep8:W291
+hacking/check_fragment.sh shebang
+hacking/find_grafana_versions.py shebang


### PR DESCRIPTION
##### SUMMARY
    
In latest versions of Grafana, the elastic version is no more provided as an integer even if it is still supported and won't return any error.
To ease configuration, the module will accept the version format as displayed by the WUI (ex: "7.10+") and will map the value to what the API expects ("7.10.0").
The added values are the one supported by Grafana 8 and 9 (greater than elastic 7.0 which was already supported).

The module will keep on supporting the old format to avoid a breaking change with significant impact.
The integer format could be dropped when Grafana 10 would be released since the versions we support would be 8.x to 10.x that will all support the new format.

Fixes: #263

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`grafana_datasource`