### PR TITLE
Use ansible-test-gh-action GHA @ integration tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -57,30 +57,13 @@ jobs:
         exclude:
           - python_version: "3.8"
             ansible_version: "devel"
-    container:
-      image: python:${{ matrix.python_version }}
     services:
       grafana:
         image: grafana/grafana:${{ matrix.grafana_version }}
     steps:
-
-      - name: Check out code
-        uses: actions/checkout@v2
+      - name: Perform testing
+        uses: ansible-community/ansible-test-gh-action@release/v1
         with:
-          path: ansible_collections/community/grafana
-
-      - name: Install ansible
-        run: pip install https://github.com/ansible/ansible/archive/${{ matrix.ansible_version }}.tar.gz --disable-pip-version-check
-
-      - name: Run integration tests on Python ${{ matrix.python_version }}
-        run: ansible-test integration -v --color --retry-on-error --requirements --python ${{ matrix.python_version }} --continue-on-error --diff --coverage
-        working-directory: ./ansible_collections/community/grafana
-      
-      - name: Generate coverage report
-        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
-        working-directory: ./ansible_collections/community/grafana
-
-      - uses: codecov/codecov-action@v2
-        with:
-          fail_ci_if_error: false
-          flags: integration
+          ansible-core-version: ${{ matrix.ansible_version }}
+          target-python-version: ${{ matrix.python_version }}
+          testing-type: integration

--- a/changelogs/fragments/270-gha--ansible-test--integration.yml
+++ b/changelogs/fragments/270-gha--ansible-test--integration.yml
@@ -1,0 +1,10 @@
+---
+
+trivial:
+  - >-
+    Simplify the GitHub workflow to use the ansible-test Action
+    for running the integration tests. This is a maintainability
+    improvement that is aiming at reducing burden of keeping the
+    CI workflows up-to-date.
+
+...


### PR DESCRIPTION
Supersedes
https://github.com/ansible-collections/community.grafana/pull/266.

This patch replaces manually maintained copy-paste of `ansible-test`
invocations with the use of a reusable GitHub Action[[1]] that wraps
it allowing to only keep the matrix on the project side allowing the
reusable bits to be maintained separately and be shared across the
community.

This has been earlier implemented for the `community.digitalocean`
collection[[2]] and some tests in this collection[[3]] among others.

The feature allowing `ansible-test` access service containers has
been implemented in v1.9.0 version of the action[[4]].

Resolves https://github.com/ansible-collections/community.grafana/pull/266

[1]: https://github.com/ansible-community/ansible-test-gh-action
[2]: https://github.com/ansible-collections/community.digitalocean/pull/144
[3]: https://github.com/ansible-collections/community.grafana/pull/270
[4]: https://github.com/ansible-community/ansible-test-gh-action/discussions/37

##### SUMMARY

See above.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Maintenance Pull Request
- Testing Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`.github/workflows/ansible-test.yml`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See above.
<!--- Paste verbatim command output below, e.g. before and after your change -->
This is also on the way of being included into the default collection skeleton at https://github.com/ansible/ansible/pull/74901/files#diff-096f7bb125bbac5751a11cfa3f7682b8d7c7c8cfffb0feddd10fb78e7346950d.