### PR TITLE
Update matrix to drop ansible 2.11 & 2.12 and add 2.14

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -12,11 +12,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python_version: ["3.8", "3.9"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
-        exclude:
-          - python_version: "3.8"
-            ansible_version: "devel"
+        python_version: ["3.9"]
+        ansible_version: ["stable-2.13", "stable-2.14", "devel"]
     steps:
       - name: Perform testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -32,11 +29,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python_version: ["3.8", "3.9"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
-        exclude:
-          - python_version: "3.8"
-            ansible_version: "devel"
+        python_version: ["3.9"]
+        ansible_version: ["stable-2.13", "stable-2.14", "devel"]
     steps:
       - name: Perform testing
         uses: ansible-community/ansible-test-gh-action@release/v1
@@ -52,11 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         grafana_version: ["9.1.7", "8.5.13", "7.5.16"]
-        ansible_version: ["stable-2.11", "stable-2.12", "stable-2.13", "devel"]
-        python_version: ["3.8", "3.9"]
-        exclude:
-          - python_version: "3.8"
-            ansible_version: "devel"
+        ansible_version: ["stable-2.13", "stable-2.14", "devel"]
+        python_version: ["3.9"]
     services:
       grafana:
         image: grafana/grafana:${{ matrix.grafana_version }}

--- a/changelogs/fragments/277-gha-ansible-test-versions.yml
+++ b/changelogs/fragments/277-gha-ansible-test-versions.yml
@@ -1,0 +1,6 @@
+---
+
+trivial:
+  - Update Python and Ansible versions used in test matrix.
+
+...


### PR DESCRIPTION
##### SUMMARY

Update GitHub Actions matrix to test with last version of Ansible (and drop old ones).

Fixes: #277 
