### PR TITLE
Correct collection URLs in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ tags:
   - monitoring
   - grafana
 dependencies: {}
-repository: https://github.com/ansible-collections/grafana.git
-documentation: https://github.com/ansible-collections/grafana.git
+repository: https://github.com/ansible-collections/community.grafana.git
+documentation: https://docs.ansible.com/ansible/latest/collections/community/grafana/
 homepage: https://github.com/ansible-collections/grafana
-issues: https://github.com/ansible-collections/grafana/issues
+issues: https://github.com/ansible-collections/community.grafana/issues


### PR DESCRIPTION
##### SUMMARY
Correct collection URLs in galaxy.yml

- The repository name is ansible-collections/community.grafana not ansible-collections/grafana
- Point to the Ansible docsite for documentation

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml
