### PR TITLE
Support alertmanager Grafana datasource

### DIFF
--- a/changelogs/fragments/287-alertmanager-datasource.yml
+++ b/changelogs/fragments/287-alertmanager-datasource.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ``community.grafana.grafana_datasource`` supports alertmanager.
+  - Support `alertmanager` as type for `grafana_datasource`

--- a/changelogs/fragments/287-alertmanager-datasource.yml
+++ b/changelogs/fragments/287-alertmanager-datasource.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ``community.grafana.grafana_datasource`` supports alertmanager.

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -49,6 +49,7 @@ options:
     - redis-datasource
     - tempo
     - quickwit-quickwit-datasource
+    - alertmanager
     type: str
   ds_url:
     description:
@@ -233,6 +234,17 @@ options:
     - Use trends or not for zabbix datasource type.
     type: bool
     default: false
+  alertmanager_implementation:
+    description:
+    - The implementation to set for the alertmanager datasource type.
+    choices:
+    - mimir
+    - cortex
+    - prometheus
+    type: str
+  alertmanager_handle_grafana_alerts:
+    description:
+    - Whether Grafana should sent alerts to this alertmanager.
   aws_auth_type:
     description:
     - Type for AWS authentication for CloudWatch datasource type (authType of grafana
@@ -644,6 +656,12 @@ def get_datasource_payload(data, org_id=None):
         json_data["tlsSkipVerify"] = True
 
     # datasource type related parameters
+    if data["ds_type"] == "alertmanager":
+        json_data["implementation"] = data["alertmanager_implementation"]
+        json_data["handleGrafanaManagedAlerts"] = data[
+            "alertmanager_handle_grafana_alerts"
+        ]
+
     if data["ds_type"] == "elasticsearch":
         json_data["maxConcurrentShardRequests"] = data["max_concurrent_shard_requests"]
         json_data["timeField"] = data["time_field"]
@@ -818,6 +836,8 @@ def setup_module_object():
                 "loki",
                 "tempo",
                 "quickwit-quickwit-datasource",
+                "loki",
+                "alertmanager",
             ]
         ),
         ds_url=dict(type="str"),
@@ -858,6 +878,8 @@ def setup_module_object():
             choices=["disable", "require", "verify-ca", "verify-full"],
         ),
         trends=dict(default=False, type="bool"),
+        alertmanager_implementation=dict(choices=["mimir", "cortex", "prometheus"]),
+        alertmanager_handle_grafana_alerts=dict(default=False, type="bool"),
         aws_auth_type=dict(
             default="keys", choices=["keys", "credentials", "arn", "default"]
         ),

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -836,7 +836,6 @@ def setup_module_object():
                 "loki",
                 "tempo",
                 "quickwit-quickwit-datasource",
-                "loki",
                 "alertmanager",
             ]
         ),

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -245,6 +245,8 @@ options:
   alertmanager_handle_grafana_alerts:
     description:
     - Whether Grafana should sent alerts to this alertmanager.
+    type: bool
+    default: false
   aws_auth_type:
     description:
     - Type for AWS authentication for CloudWatch datasource type (authType of grafana

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -244,7 +244,7 @@ options:
     type: str
   alertmanager_handle_grafana_alerts:
     description:
-    - Whether Grafana should sent alerts to this alertmanager.
+    - Whether Grafana should send alerts to this alertmanager.
     type: bool
     default: false
   aws_auth_type:

--- a/tests/integration/targets/grafana_datasource/tasks/alertmanager.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/alertmanager.yml
@@ -40,7 +40,6 @@
     - not result.changed
     - result.datasource.basicAuth == false
     - result.datasource.isDefault == false
-    - result.datasource.jsonData.sslmode == 'verify-full'
     - result.datasource.jsonData.tlsAuth == false
     - result.datasource.jsonData.tlsAuthWithCACert == false
     - result.datasource.jsonData.implementation == 'prometheus'
@@ -66,6 +65,7 @@
 - assert:
     that:
     - result.changed
+    - "result.msg == 'Datasource datasource-alertmanager deleted.'"
 
 - name: Delete alertmanager datasource
   register: result

--- a/tests/integration/targets/grafana_datasource/tasks/alertmanager.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/alertmanager.yml
@@ -1,0 +1,84 @@
+- name: Create alertmanager datasource
+  register: result
+  grafana_datasource:
+    name: datasource-alertmanager
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: alertmanager
+    ds_url: alertmanager.company.com:9093
+    alertmanager_implementation: prometheus
+    alertmanager_handle_grafana_alerts: false
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - "result.msg == 'Datasource datasource-alertmanager created'"
+
+- name: Check alertmanager datasource creation idempotency
+  register: result
+  grafana_datasource:
+    name: datasource-alertmanager
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: alertmanager
+    ds_url: alertmanager.company.com:9093
+    alertmanager_implementation: prometheus
+    alertmanager_handle_grafana_alerts: false
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - not result.changed
+    - result.datasource.basicAuth == false
+    - result.datasource.isDefault == false
+    - result.datasource.jsonData.sslmode == 'verify-full'
+    - result.datasource.jsonData.tlsAuth == false
+    - result.datasource.jsonData.tlsAuthWithCACert == false
+    - result.datasource.jsonData.implementation == 'prometheus'
+    - result.datasource.jsonData.handleGrafanaManagedAlerts == false
+    - result.datasource.name == 'datasource-alertmanager'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'alertmanager'
+    - result.datasource.url == 'alertmanager.company.com:9093'
+    - result.datasource.withCredentials == false
+
+- name: Delete alertmanager datasource
+  register: result
+  grafana_datasource:
+    name: datasource-alertmanager
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: absent
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+
+- name: Delete alertmanager datasource
+  register: result
+  grafana_datasource:
+    name: datasource-alertmanager
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: absent
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - not result.changed

--- a/tests/integration/targets/grafana_datasource/tasks/main.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - block:
     - ansible.builtin.include_tasks:
+        file: alertmanager.yml
+    - ansible.builtin.include_tasks:
         file: errors.yml
     - ansible.builtin.include_tasks:
         file: elastic.yml


### PR DESCRIPTION
##### SUMMARY
This adds the "alertmanager" datasource. [Apparently added in Grafana 9.2.](https://grafana.com/docs/grafana/latest/whatsnew/whats-new-in-v9-2/#configure-external-alertmanagers-as-data-sources)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_datasource plugin