### PR TITLE
get_actual_org url encode fix

### DIFF
--- a/changelogs/fragments/288_get_actual_org_encode.yml
+++ b/changelogs/fragments/288_get_actual_org_encode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - URL encode issue in grafana_organization.py (method get_actual_org ) fixed.

--- a/plugins/modules/grafana_organization.py
+++ b/plugins/modules/grafana_organization.py
@@ -101,6 +101,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
+from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 
@@ -139,7 +140,7 @@ class GrafanaOrgInterface(object):
 
     def get_actual_org(self, name):
         # https://grafana.com/docs/grafana/latest/http_api/org/#get-organization-by-name
-        url = "/api/orgs/name/{name}".format(name=name)
+        url = "/api/orgs/name/{name}".format(name=quote(name))
         return self._send_request(url, headers=self.headers, method="GET")
 
     def create_org(self, name):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the issue when creating an org with spaces in it's name.

you would get the following error:
`Cannot connect to API Grafana An unknown error occurred: URL can't contain control characters. \"/api/orgs/name/'Test Org space'\" (found at least ' ')`

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_organization module

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Having spaces in the org name might not be for everyone, but it is allowed by grafana it self.
```
