### PR TITLE
Fixed validate_certs missing parameter for --insecure option while in…

### DIFF
--- a/changelogs/fragments/1.5.3.yml
+++ b/changelogs/fragments/1.5.3.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fixed validate_certs missing parameter for --insecure option in grafana plugins

--- a/plugins/modules/grafana_plugin.py
+++ b/plugins/modules/grafana_plugin.py
@@ -47,6 +47,11 @@ options:
     - absent
     default: present
     type: str
+  validate_certs:
+    description:
+    - Boolean variable to include --insecure while installing pluging
+    default: False
+    type: bool
 '''
 
 EXAMPLES = '''
@@ -232,6 +237,7 @@ def main():
             grafana_plugins_dir=dict(type='str'),
             grafana_repo=dict(type='str'),
             grafana_plugin_url=dict(type='str'),
+            validate_certs=dict(type='bool', default=False),
             state=dict(choices=['present', 'absent'],
                        default='present')
         ),


### PR DESCRIPTION
…stalling grafana plugins with ansible

##### SUMMARY
Validate certs option available in code 
https://github.com/ansible-collections/community.grafana/blob/main/plugins/modules/grafana_plugin.py#L119

but not available as parameter
https://github.com/ansible-collections/community.grafana/blob/main/plugins/modules/grafana_plugin.py#L234

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
grafana_plugin


##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes -->
```paste below
2.12.2
```

##### COLLECTION VERSION
<!--- Paste verbatim output from "ansible-galaxy collection list <namespace>.<collection>"  between the quotes
for example: ansible-galaxy collection list community.general
-->
```paste below
Colletion  Version
----------------------
community.general 1.3.2

Colletion  Version
----------------------
community.general 1.5.3

```

##### CONFIGURATION
<!--- Paste verbatim output from "ansible-config dump --only-changed" between quotes -->
```paste below

```

##### OS / ENVIRONMENT
<!--- Provide all relevant information below, e.g. target OS versions, network device firmware, etc. -->
RH8

##### STEPS TO REPRODUCE
<!--- Describe exactly how to reproduce the problem, using a minimal test-case -->

<!--- Paste example playbooks or commands between quotes below -->
```yaml
- name: Install plugins
  community.grafana.grafana_plugin:
    name: alexanderzobnin-zabbix-app
    version: 4.2.10
    state: present
    validate_certs: False
```

<!--- HINT: You can paste gist.github.com links for larger files -->

##### EXPECTED RESULTS
<!--- Describe what you expected to happen when running the steps above -->
No error and command to be executed with --insecure

##### ACTUAL RESULTS
<!--- Describe what actually happened. If possible run with extra verbosity (-vvvv) -->
"msg": "Unsupported parameters for (community.grafana.grafana_plugin) module: validate_certs. Supported parameters include: grafana_plugins_dir, state, grafana_plugin_url, version, grafana_repo, name."


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before
            grafana_plugin_url=dict(type='str'),
            state=dict(choices=['present', 'absent'],
                       default='present')
        ),
After
            grafana_plugin_url=dict(type='str'),
            validate_certs=dict(type='bool', default=False),
            state=dict(choices=['present', 'absent'],
                       default='present')
        ),
```


