### PR TITLE
eable option org_id for folder and team

### DIFF
--- a/changelogs/fragments/org_id_option_folder_and_team.yml
+++ b/changelogs/fragments/org_id_option_folder_and_team.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - Enable option `org_id` for grafana_folder
+  - Enable option `org_id` for grafana_team


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Enable `org_id` option for grafana_folder and grafana_team

Allows to configure folders and teams within a particular organization.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
