### PR TITLE
grafana_folder: fix grafana server empty response content

### DIFF
--- a/changelogs/fragments/fix_remove_folder_response_content.yml
+++ b/changelogs/fragments/fix_remove_folder_response_content.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - grafana_folder: fix grafana server empty response content

--- a/plugins/modules/grafana_folder.py
+++ b/plugins/modules/grafana_folder.py
@@ -215,7 +215,9 @@ class GrafanaFolderInterface(object):
             error_msg = resp.read()['message']
             self._module.fail_json(failed=True, msg=error_msg)
         elif status_code == 200:
-            return self._module.from_json(resp.read())
+            text = resp.read() or '{}'
+            return self._module.from_json(text)
+
         self._module.fail_json(failed=True, msg="Grafana Folders API answered with HTTP %d" % status_code)
 
     def get_version(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Handle empty response content from grafana API server.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_folder
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Grafana API server appears to return empty content in some cases.

I encountered the problem when removing a folder (`state: absent`) with a grafana 9.3.6 server

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste be

```
