### PR TITLE
add Quickwit datasource

### DIFF
--- a/changelogs/fragments/308_datasource_quickwit.yml
+++ b/changelogs/fragments/308_datasource_quickwit.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add Quickwit search engine datasource (https://quickwit.io).

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -48,6 +48,7 @@ options:
     - loki
     - redis-datasource
     - tempo
+    - quickwit-quickwit-datasource
     type: str
   ds_url:
     description:
@@ -790,6 +791,7 @@ def setup_module_object():
                 "redis-datasource",
                 "loki",
                 "tempo",
+                "quickwit-quickwit-datasource",
             ]
         ),
         ds_url=dict(type="str"),

--- a/tests/integration/targets/grafana_datasource/tasks/quickwit.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/quickwit.yml
@@ -1,138 +1,137 @@
 ---
-
 - name: Create Quickwit datasource
   register: result
-  grafana_datasource:
-    name: "Quickwit"
+  community.grafana.grafana_datasource:
+    name: Quickwit
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
+    org_id: "1"
     ds_type: quickwit-quickwit-datasource
     ds_url: http://localhost:7280/api/v1
     additional_json_data:
-      index: 'hdfs-logs'
+      index: hdfs-logs
       timeField: timestamp
       timeOutputFormat: unix_timestamp_secs
       logMessageField: body
       logLevelField: severity_text
 
-- debug:
+- ansible.builtin.debug:
     var: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result.changed
-    - result.datasource.access == 'proxy'
-    - not result.datasource.isDefault
-    - result.datasource.database == ''
-    - result.datasource.name == 'Quickwit'
-    - result.datasource.orgId == 1
-    - result.datasource.type == 'quickwit-quickwit-datasource'
-    - result.datasource.url == 'http://localhost:7280/api/v1'
-    - "result.msg == 'Datasource Quickwit created'"
-    - result.datasource.jsonData.index == 'hdfs-logs'
-    - result.datasource.jsonData.timeField == 'timestamp'
-    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
-    - result.datasource.jsonData.logMessageField == 'body'
-    - result.datasource.jsonData.logLevelField == 'severity_text'
+      - result.changed
+      - result.datasource.access == 'proxy'
+      - not result.datasource.isDefault
+      - result.datasource.database == ''
+      - result.datasource.name == 'Quickwit'
+      - result.datasource.orgId == 1
+      - result.datasource.type == 'quickwit-quickwit-datasource'
+      - result.datasource.url == 'http://localhost:7280/api/v1'
+      - result.msg == 'Datasource Quickwit created'
+      - result.datasource.jsonData.index == 'hdfs-logs'
+      - result.datasource.jsonData.timeField == 'timestamp'
+      - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
+      - result.datasource.jsonData.logMessageField == 'body'
+      - result.datasource.jsonData.logLevelField == 'severity_text'
 
 - name: Check Quickwit datasource creation (idempotency)
   register: result
-  grafana_datasource:
-    name: "Quickwit"
+  community.grafana.grafana_datasource:
+    name: Quickwit
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
+    org_id: "1"
     ds_type: quickwit-quickwit-datasource
     ds_url: http://localhost:7280/api/v1
     additional_json_data:
-      index: 'hdfs-logs'
+      index: hdfs-logs
       timeField: timestamp
       timeOutputFormat: unix_timestamp_secs
       logMessageField: body
       logLevelField: severity_text
 
-- debug:
+- ansible.builtin.debug:
     var: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - not result.changed
-    - result.datasource.access == 'proxy'
-    - not result.datasource.isDefault
-    - result.datasource.database == ''
-    - result.datasource.name == 'Quickwit'
-    - result.datasource.orgId == 1
-    - result.datasource.type == 'quickwit-quickwit-datasource'
-    - result.datasource.url == 'http://localhost:7280/api/v1'
-    - "result.msg == 'Datasource Quickwit created'"
-    - result.datasource.jsonData.index == 'hdfs-logs'
-    - result.datasource.jsonData.timeField == 'timestamp'
-    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
-    - result.datasource.jsonData.logMessageField == 'body'
-    - result.datasource.jsonData.logLevelField == 'severity_text'
+      - not result.changed
+      - result.datasource.access == 'proxy'
+      - not result.datasource.isDefault
+      - result.datasource.database == ''
+      - result.datasource.name == 'Quickwit'
+      - result.datasource.orgId == 1
+      - result.datasource.type == 'quickwit-quickwit-datasource'
+      - result.datasource.url == 'http://localhost:7280/api/v1'
+      - result.msg == 'Datasource Quickwit created'
+      - result.datasource.jsonData.index == 'hdfs-logs'
+      - result.datasource.jsonData.timeField == 'timestamp'
+      - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
+      - result.datasource.jsonData.logMessageField == 'body'
+      - result.datasource.jsonData.logLevelField == 'severity_text'
 
 - name: Update Quickwit datasource
   register: result
-  grafana_datasource:
-    name: "Quickwit"
+  community.grafana.grafana_datasource:
+    name: Quickwit
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
-    org_id: '1'
+    org_id: "1"
     ds_type: quickwit-quickwit-datasource
     ds_url: http://quickwit-url:7280/api/v1
     additional_json_data:
-      index: 'hdfs-logs'
+      index: hdfs-logs
       timeField: timestamp
       timeOutputFormat: unix_timestamp_millis
       logMessageField: body
       logLevelField: severity_text
 
-- debug:
+- ansible.builtin.debug:
     var: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result.changed
-    - result.datasource.access == 'proxy'
-    - not result.datasource.isDefault
-    - result.datasource.database == ''
-    - result.datasource.name == 'Quickwit'
-    - result.datasource.orgId == 1
-    - result.datasource.type == 'quickwit-quickwit-datasource'
-    - result.datasource.url == 'http://quickwit-url:7280/api/v1'
-    - "result.msg == 'Datasource Quickwit created'"
-    - result.datasource.jsonData.index == 'hdfs-logs'
-    - result.datasource.jsonData.timeField == 'timestamp'
-    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_millis'
-    - result.datasource.jsonData.logMessageField == 'body'
-    - result.datasource.jsonData.logLevelField == 'severity_text'
+      - result.changed
+      - result.datasource.access == 'proxy'
+      - not result.datasource.isDefault
+      - result.datasource.database == ''
+      - result.datasource.name == 'Quickwit'
+      - result.datasource.orgId == 1
+      - result.datasource.type == 'quickwit-quickwit-datasource'
+      - result.datasource.url == 'http://quickwit-url:7280/api/v1'
+      - result.msg == 'Datasource Quickwit created'
+      - result.datasource.jsonData.index == 'hdfs-logs'
+      - result.datasource.jsonData.timeField == 'timestamp'
+      - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_millis'
+      - result.datasource.jsonData.logMessageField == 'body'
+      - result.datasource.jsonData.logLevelField == 'severity_text'
 
 - name: Delete Quickwit datasource
   register: result
-  grafana_datasource:
-    name: "Quickwit"
+  community.grafana.grafana_datasource:
+    name: Quickwit
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
     state: absent
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result.changed
+      - result.changed
 
 - name: Delete Quickwit datasource (idempotency)
   register: result
-  grafana_datasource:
-    name: "Quickwit"
+  community.grafana.grafana_datasource:
+    name: Quickwit
     grafana_url: "{{ grafana_url }}"
     grafana_user: "{{ grafana_username }}"
     grafana_password: "{{ grafana_password }}"
     state: absent
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - not result.changed
+      - not result.changed

--- a/tests/integration/targets/grafana_datasource/tasks/quickwit.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/quickwit.yml
@@ -1,0 +1,138 @@
+---
+
+- name: Create Quickwit datasource
+  register: result
+  grafana_datasource:
+    name: "Quickwit"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: quickwit-quickwit-datasource
+    ds_url: http://localhost:7280/api/v1
+    additional_json_data:
+      index: 'hdfs-logs'
+      timeField: timestamp
+      timeOutputFormat: unix_timestamp_secs
+      logMessageField: body
+      logLevelField: severity_text
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.database == ''
+    - result.datasource.name == 'Quickwit'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'quickwit-quickwit-datasource'
+    - result.datasource.url == 'http://localhost:7280/api/v1'
+    - "result.msg == 'Datasource Quickwit created'"
+    - result.datasource.jsonData.index == 'hdfs-logs'
+    - result.datasource.jsonData.timeField == 'timestamp'
+    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
+    - result.datasource.jsonData.logMessageField == 'body'
+    - result.datasource.jsonData.logLevelField == 'severity_text'
+
+- name: Check Quickwit datasource creation (idempotency)
+  register: result
+  grafana_datasource:
+    name: "Quickwit"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: quickwit-quickwit-datasource
+    ds_url: http://localhost:7280/api/v1
+    additional_json_data:
+      index: 'hdfs-logs'
+      timeField: timestamp
+      timeOutputFormat: unix_timestamp_secs
+      logMessageField: body
+      logLevelField: severity_text
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - not result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.database == ''
+    - result.datasource.name == 'Quickwit'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'quickwit-quickwit-datasource'
+    - result.datasource.url == 'http://localhost:7280/api/v1'
+    - "result.msg == 'Datasource Quickwit created'"
+    - result.datasource.jsonData.index == 'hdfs-logs'
+    - result.datasource.jsonData.timeField == 'timestamp'
+    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_secs'
+    - result.datasource.jsonData.logMessageField == 'body'
+    - result.datasource.jsonData.logLevelField == 'severity_text'
+
+- name: Update Quickwit datasource
+  register: result
+  grafana_datasource:
+    name: "Quickwit"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    org_id: '1'
+    ds_type: quickwit-quickwit-datasource
+    ds_url: http://quickwit-url:7280/api/v1
+    additional_json_data:
+      index: 'hdfs-logs'
+      timeField: timestamp
+      timeOutputFormat: unix_timestamp_millis
+      logMessageField: body
+      logLevelField: severity_text
+
+- debug:
+    var: result
+
+- assert:
+    that:
+    - result.changed
+    - result.datasource.access == 'proxy'
+    - not result.datasource.isDefault
+    - result.datasource.database == ''
+    - result.datasource.name == 'Quickwit'
+    - result.datasource.orgId == 1
+    - result.datasource.type == 'quickwit-quickwit-datasource'
+    - result.datasource.url == 'http://quickwit-url:7280/api/v1'
+    - "result.msg == 'Datasource Quickwit created'"
+    - result.datasource.jsonData.index == 'hdfs-logs'
+    - result.datasource.jsonData.timeField == 'timestamp'
+    - result.datasource.jsonData.timeOutputFormat == 'unix_timestamp_millis'
+    - result.datasource.jsonData.logMessageField == 'body'
+    - result.datasource.jsonData.logLevelField == 'severity_text'
+
+- name: Delete Quickwit datasource
+  register: result
+  grafana_datasource:
+    name: "Quickwit"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: absent
+
+- assert:
+    that:
+    - result.changed
+
+- name: Delete Quickwit datasource (idempotency)
+  register: result
+  grafana_datasource:
+    name: "Quickwit"
+    grafana_url: "{{ grafana_url }}"
+    grafana_user: "{{ grafana_username }}"
+    grafana_password: "{{ grafana_password }}"
+    state: absent
+
+- assert:
+    that:
+    - not result.changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add support Quickwit datasource
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
datasource

##### ADDITIONAL INFORMATION
https://github.com/quickwit-oss/quickwit-datasource

Example usage
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create Quickwit datasource
  community.grafana.grafana_datasource::
    name: "Quickwit"
    grafana_url: "{{ grafana_url }}"
    grafana_user: "{{ grafana_username }}"
    grafana_password: "{{ grafana_password }}"
    access: proxy
    org_id: '1'
    ds_type: quickwit-quickwit-datasource
    ds_url: http://localhost:7280/api/v1
    additional_json_data:
      index: 'hdfs-logs'
      timeField: timestamp
      timeOutputFormat: unix_timestamp_secs
      logMessageField: body
      logLevelField: severity_text
```
