### PR TITLE
Bump requests from 2.28.2 to 2.31.0

### DIFF
--- a/hacking/requirements.txt
+++ b/hacking/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.28.0
+requests==2.31.0


### PR DESCRIPTION
##### SUMMARY

I bumped requests library 2.28.2 to 2.31.0, because my environment dependabot alert to requests 2.28.2.
I understood this code is part of CI and this has no effect.
But this is annoying warning for users with dependabot enabled.
this is just suggestion, if this project decide to don't care it, please just close this PR.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

https://github.com/advisories/GHSA-j8r2-6x86-q33q
