### PR TITLE
Fix KeyError when comparing datasource without basicAuth

### DIFF
--- a/changelogs/fragments/fix-316.yml
+++ b/changelogs/fragments/fix-316.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix error with datasources configured without basicAuth

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -520,7 +520,7 @@ def compare_datasources(new, current, compareSecureData=True):
         del current['readOnly']
     if current['basicAuth'] is False:
         if 'basicAuthUser' in current:
-          del current['basicAuthUser']
+            del current['basicAuthUser']
     if 'password' in current:
         del current['password']
     if 'basicAuthPassword' in current:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -519,7 +519,8 @@ def compare_datasources(new, current, compareSecureData=True):
     if 'readOnly' in current:
         del current['readOnly']
     if current['basicAuth'] is False:
-        del current['basicAuthUser']
+        if 'basicAuthUser' in current:
+          del current['basicAuthUser']
     if 'password' in current:
         del current['password']
     if 'basicAuthPassword' in current:


### PR DESCRIPTION
If there is no check for its presence, this will fail if a datasource is not configured with basic auth at all. In that case it would try to remove an entry from the dict that is not there resulting in a KeyError.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When comparing the existing datasource with the should be state, basicAuth is handled incorrectly in the case when the datasource is not configured with basicAuth at all. This case would result in a KeyError which this change fixes.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_datasource.py

See also https://github.com/ansible-collections/community.grafana/issues/248
