### PR TITLE
feat(organization_user): manage users by org_name

### DIFF
--- a/changelogs/fragments/318-org_users_by_org_name.yml
+++ b/changelogs/fragments/318-org_users_by_org_name.yml
@@ -1,0 +1,4 @@
+---
+
+minor_changes:
+  - Add parameter `org_name` to `grafana_organization_user`

--- a/changelogs/fragments/318-org_users_by_org_name.yml
+++ b/changelogs/fragments/318-org_users_by_org_name.yml
@@ -2,3 +2,6 @@
 
 minor_changes:
   - Add parameter `org_name` to `grafana_organization_user`
+
+trivial:
+  - Add tests for new `grafana_organization_user`-parameter `org_name`

--- a/plugins/modules/grafana_organization_user.py
+++ b/plugins/modules/grafana_organization_user.py
@@ -244,7 +244,7 @@ def main():
     argument_spec.pop('grafana_api_key')
     argument_spec.update(
         org_id=dict(type='int', default=1),
-        org_name=dict(type='str', required=False),
+        org_name=dict(type='str'),
         login=dict(type='str', required=True),
         role=dict(type='str', choices=['viewer', 'editor', 'admin'], default='viewer'),
     )

--- a/plugins/modules/grafana_organization_user.py
+++ b/plugins/modules/grafana_organization_user.py
@@ -57,6 +57,12 @@ options:
     default: 1
     description:
       - Organization ID.
+      - Mutually exclusive with `org_name`.
+  org_name:
+    type: str
+    description:
+      - Organization name.
+      - Mutually exclusive with `org_id`.
 
 extends_documentation_fragment:
   - community.grafana.basic_auth

--- a/plugins/modules/grafana_organization_user.py
+++ b/plugins/modules/grafana_organization_user.py
@@ -264,8 +264,8 @@ def main():
     iface = GrafanaOrganizationUserInterface(module)
     if module.params['org_name']:
         org_name = module.params['org_name']
-        result = iface._organization_by_name(org_name)
-        module.exit_json(failed=False, **result)
+        organization = iface._organization_by_name(org_name)
+        org_id = organization['id']
     if module.params['state'] == 'present':
         role = module.params['role'].capitalize()
         result = iface.create_or_update_user(org_id, login, role)

--- a/plugins/modules/grafana_organization_user.py
+++ b/plugins/modules/grafana_organization_user.py
@@ -190,7 +190,7 @@ class GrafanaOrganizationUserInterface(object):
 
     def _organization_user_by_login(self, org_id, login):
         for user in self._organization_users(org_id):
-            if user['name'] == login or user['email'] == login:
+            if login in (user['login'], user['email']):
                 return user
 
     def create_or_update_user(self, org_id, login, role):

--- a/tests/integration/targets/grafana_organization_user/tasks/main.yml
+++ b/tests/integration/targets/grafana_organization_user/tasks/main.yml
@@ -92,7 +92,7 @@
     state: present
   register: org
 
-- name: Add user to the organization
+- name: Add user to the new organization by org_id
   community.grafana.grafana_organization_user:
     url: "{{ grafana_url }}"
     url_username: "{{ grafana_username }}"
@@ -108,3 +108,48 @@
       - "result.changed == true"
       - "result.user.orgId == org.org.id"
       - "result.user.role == 'Admin'"
+
+- name: Remove user from new organization by org_id
+  community.grafana.grafana_organization_user:
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
+    org_id: "{{ org.org.id }}"
+    login: orgtest
+    state: absent
+  register: result
+- assert:
+    that:
+      - "result.failed == false"
+      - "result.changed == true"
+
+- name: Add user to the new organization by org_name
+  community.grafana.grafana_organization_user:
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
+    org_name: "{{ org.org.name }}"
+    login: orgtest
+    role: admin
+    state: present
+  register: result
+- assert:
+    that:
+      - "result.failed == false"
+      - "result.changed == true"
+      - "result.user.orgId == org.org.id"
+      - "result.user.role == 'Admin'"
+
+- name: Remove user from new organization by org_name
+  community.grafana.grafana_organization_user:
+    url: "{{ grafana_url }}"
+    url_username: "{{ grafana_username }}"
+    url_password: "{{ grafana_password }}"
+    org_name: "{{ org.org.name }}"
+    login: orgtest
+    state: absent
+  register: result
+- assert:
+    that:
+      - "result.failed == false"
+      - "result.changed == true"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
- (Bugfix Pull Request)

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
**module**: grafana_organization_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This PR adds the ability to manage organization users by `org_name`, not just `org_id`.
... and a small bugfix to check if user is already in organization.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
