### PR TITLE
fix: add grafana_organization_user to action_group grafana

### DIFF
--- a/changelogs/fragments/321-action-groups-org-users.yml
+++ b/changelogs/fragments/321-action-groups-org-users.yml
@@ -1,0 +1,4 @@
+---
+
+bugfixes:
+  - Add `grafana_organiazion_user` to `action_groups.grafana`

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -2,11 +2,12 @@
 requires_ansible: '>=2.9.0'
 action_groups:
   grafana:
-  - grafana_dashboard
-  - grafana_datasource
-  - grafana_folder
-  - grafana_notification_channel
-  - grafana_organization
-  - grafana_plugin
-  - grafana_team
-  - grafana_user
+    - grafana_dashboard
+    - grafana_datasource
+    - grafana_folder
+    - grafana_notification_channel
+    - grafana_organization
+    - grafana_organization_user
+    - grafana_plugin
+    - grafana_team
+    - grafana_user


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`grafana_organization_user` was missing in `action_groups.grafana`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
**module:** grafana_organization_user

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
