### PR TITLE
fix(grafana_datasource): orgId by name if defined to compare diff

### DIFF
--- a/changelogs/fragments/345-datasource-compare-diff-orgid.yml
+++ b/changelogs/fragments/345-datasource-compare-diff-orgid.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - `grafana_datasource` get orgId by name if defined to compare diff
+  - Fixed orgId handling in diff comparison for `grafana_datasource` if using org_name

--- a/changelogs/fragments/345-datasource-compare-diff-orgid.yml
+++ b/changelogs/fragments/345-datasource-compare-diff-orgid.yml
@@ -1,3 +1,3 @@
 ---
-bugfix:
+bugfixes:
   - `grafana_datasource` get orgId by name if defined to compare diff

--- a/changelogs/fragments/345-datasource-compare-diff-orgid.yml
+++ b/changelogs/fragments/345-datasource-compare-diff-orgid.yml
@@ -1,0 +1,3 @@
+---
+bugfix:
+  - `grafana_datasource` get orgId by name if defined to compare diff

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -559,9 +559,9 @@ def compare_datasources(new, current, compareSecureData=True):
     return dict(before=current, after=new)
 
 
-def get_datasource_payload(data, org_id):
+def get_datasource_payload(data):
     payload = {
-        "orgId": org_id,
+        "orgId": data["org_id"],
         "name": data["name"],
         "uid": data["uid"],
         "type": data["ds_type"],
@@ -921,14 +921,15 @@ def main():
 
     grafana_iface = GrafanaInterface(module)
     ds = grafana_iface.datasource_by_name(name)
-    org_id = (
-        grafana_iface.organization_by_name(module.params["org_name"])
-        if module.params["org_name"]
-        else module.params["org_id"]
-    )
 
     if state == "present":
-        payload = get_datasource_payload(module.params, org_id)
+        params = module.params
+        params["org_id"] = (
+            grafana_iface.organization_by_name(params["org_name"])
+            if params["org_name"]
+            else params["org_id"]
+        )
+        payload = get_datasource_payload(params)
         if ds is None:
             grafana_iface.create_datasource(payload)
             ds = grafana_iface.datasource_by_name(name)

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -559,9 +559,9 @@ def compare_datasources(new, current, compareSecureData=True):
     return dict(before=current, after=new)
 
 
-def get_datasource_payload(data):
+def get_datasource_payload(data, org_id):
     payload = {
-        "orgId": data["org_id"],
+        "orgId": org_id,
         "name": data["name"],
         "uid": data["uid"],
         "type": data["ds_type"],
@@ -921,9 +921,14 @@ def main():
 
     grafana_iface = GrafanaInterface(module)
     ds = grafana_iface.datasource_by_name(name)
+    org_id = (
+        grafana_iface.organization_by_name(module.params["org_name"])
+        if module.params["org_name"]
+        else module.params["org_id"]
+    )
 
     if state == "present":
-        payload = get_datasource_payload(module.params)
+        payload = get_datasource_payload(module.params, org_id)
         if ds is None:
             grafana_iface.create_datasource(payload)
             ds = grafana_iface.datasource_by_name(name)

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -559,9 +559,9 @@ def compare_datasources(new, current, compareSecureData=True):
     return dict(before=current, after=new)
 
 
-def get_datasource_payload(data):
+def get_datasource_payload(data, org_id=None):
     payload = {
-        "orgId": data["org_id"],
+        "orgId": data["org_id"] if org_id is None else org_id,
         "name": data["name"],
         "uid": data["uid"],
         "type": data["ds_type"],
@@ -923,13 +923,12 @@ def main():
     ds = grafana_iface.datasource_by_name(name)
 
     if state == "present":
-        params = module.params
-        params["org_id"] = (
-            grafana_iface.organization_by_name(params["org_name"])
-            if params["org_name"]
-            else params["org_id"]
+        org_id = (
+            grafana_iface.organization_by_name(module.params["org_name"])
+            if module.params["org_name"]
+            else module.params["org_id"]
         )
-        payload = get_datasource_payload(params)
+        payload = get_datasource_payload(module.params, org_id)
         if ds is None:
             grafana_iface.create_datasource(payload)
             ds = grafana_iface.datasource_by_name(name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If `org_name` is set instead of `org_id`, comparing the diff (after/before) to determine whether something has changed or not does not work.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- module `grafana_datasource`
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```json
    "diff": {
        "after": {
            "access": "proxy",
            "basicAuth": false,
            "database": "",
            "isDefault": false,
            "jsonData": {
                "tlsAuth": false,
                "tlsAuthWithCACert": false
            },
            "name": "Loki",
            "orgId": 1, # <-- datasource left unchanged in orgId 6 but diff uses default value of org_id (1) to compare so it's "changed"
            "type": "loki",
            "url": "http://loki-stack-loki-stack:3100",
            "user": "",
            "withCredentials": false
        },
        "before": {
            "access": "proxy",
            "basicAuth": false,
            "database": "",
            "isDefault": false,
            "jsonData": {
                "tlsAuth": false,
                "tlsAuthWithCACert": false
            },
            "name": "Loki",
            "orgId": 6,
            "type": "loki",
            "url": "http://loki-stack-loki-stack:3100",
            "user": "",
            "withCredentials": false
        }
    },
```
