### PR TITLE
docs(grafana_datasource): add influxdb flux example

### DIFF
--- a/changelogs/fragments/353-docs-add-influxdb-flux-example.yml
+++ b/changelogs/fragments/353-docs-add-influxdb-flux-example.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
+trivial:
   - grafana_datasource - (docs) add influxdb v2 flux example

--- a/changelogs/fragments/353-docs-add-influxdb-flux-example.yml
+++ b/changelogs/fragments/353-docs-add-influxdb-flux-example.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - grafana_datasource - (docs) add influxdb v2 flux example

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -400,6 +400,23 @@ EXAMPLES = """
     time_interval: ">10s"
     tls_ca_cert: "/etc/ssl/certs/ca.pem"
 
+- name: Create influxdbv2 datasource using fluxql
+  community.grafana.grafana_datasource:
+    name: "datasource-influxdb-flux"
+    grafana_url: "https://grafana.company.com"
+    grafana_user: "admin"
+    grafana_password: "xxxxxx"
+    org_id: "1"
+    ds_type: "influxdb"
+    ds_url: "https://influx.company.com:8086"
+    additional_json_data:
+      version: "Flux"
+      organization: "organization"
+      defaultBucket: "bucket"
+      tlsSkipVerify: false
+    additional_secure_json_data:
+      token: "token"
+
 - name: Create postgres datasource
   community.grafana.grafana_datasource:
     name: "datasource-postgres"


### PR DESCRIPTION
##### SUMMARY
I've added an example to grafana_datasource to add the flux version of influxdb programatically. It's very hard to find documentation online, especially for people new to ansible (and grafana).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
grafana_datasource


