### PR TITLE
ci: fix get latest grafana versions python script

### DIFF
--- a/changelogs/fragments/354-fix-find-grafana-versions.yml
+++ b/changelogs/fragments/354-fix-find-grafana-versions.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - fix find grafana versions python script comparation

--- a/hacking/check_fragment.sh
+++ b/hacking/check_fragment.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function fail() {
-    cat << EOF
+	cat <<EOF
     Dear contributor,
 
     Thank you for you Pull Request !
@@ -10,7 +10,7 @@ function fail() {
     It will help your change be released faster !
     Thank you !
 EOF
-    exit 1
+	exit 1
 }
 
 FRAGMENTS=$(git fetch && git diff --name-only --diff-filter=ACMRT origin/main..HEAD | grep "changelogs")

--- a/hacking/find_grafana_versions.py
+++ b/hacking/find_grafana_versions.py
@@ -7,12 +7,12 @@ import requests
 def get_by_major(version):
     if version.startswith("v"):
         version = version[1:]
-    return (version[0], version, int(version.replace(".", "")))
+    return int(version.split(".")[0]), version, tuple(map(int, version.split(".")))
 
 
 def get_grafana_releases():
     r = requests.get(
-        "https://api.github.com/repos/grafana/grafana/releases?per_page=50",
+        "https://api.github.com/repos/grafana/grafana/releases?per_page=100",
         headers={"Accept": "application/vnd.github.v3+json"},
     )
     if r.status_code != 200:
@@ -20,19 +20,18 @@ def get_grafana_releases():
     return r.json()
 
 
-by_major = {}
-
 if __name__ == "__main__":
     releases = get_grafana_releases()
-    for item in releases:
-        if item.get("prerelease"):
-            continue
-        major, version, as_int = get_by_major(item.get("tag_name"))
-        if major not in by_major.keys() or by_major[major]["as_int"] < as_int:
-            by_major[major] = {"version": version, "as_int": as_int}
-    latest_3_majors = sorted(list(by_major.keys()), reverse=True)[:3]
+    by_major = {}
 
-    latest_releases = []
-    for idx in latest_3_majors:
-        latest_releases.append(by_major[idx]["version"])
+    for release in releases:
+        if release.get("prerelease"):
+            continue
+        major, version, as_tuple = get_by_major(release.get("tag_name"))
+        if major not in by_major.keys() or by_major[major]["as_tuple"] < as_tuple:
+            by_major[major] = {"version": version, "as_tuple": as_tuple}
+
+    latest_3_majors = sorted(list(by_major.keys()))[:3]
+    latest_releases = [by_major[idx]["version"] for idx in latest_3_majors]
+
     print(json.dumps(latest_releases))

--- a/hacking/find_grafana_versions.py
+++ b/hacking/find_grafana_versions.py
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     by_major = {}
 
     for release in releases:
-        if release.get("prerelease"):
+        if release.get("prerelease") or any(char in release.get("tag_name") for char in "-+"):
             continue
         major, version, as_tuple = get_by_major(release.get("tag_name"))
         if major not in by_major.keys() or by_major[major]["as_tuple"] < as_tuple:

--- a/hacking/find_grafana_versions.py
+++ b/hacking/find_grafana_versions.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import json
 import requests

--- a/hacking/find_grafana_versions.py
+++ b/hacking/find_grafana_versions.py
@@ -25,7 +25,9 @@ if __name__ == "__main__":
     by_major = {}
 
     for release in releases:
-        if release.get("prerelease") or any(char in release.get("tag_name") for char in "-+"):
+        if release.get("prerelease") or any(
+            char in release.get("tag_name") for char in "-+"
+        ):
             continue
         major, version, as_tuple = get_by_major(release.get("tag_name"))
         if major not in by_major.keys() or by_major[major]["as_tuple"] < as_tuple:

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,0 @@
-plugins/modules/grafana_dashboard.py validate-modules:invalid-argument-name
-tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py pep8:W291
-hacking/check_fragment.sh shebang
-hacking/find_grafana_versions.py shebang

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,0 @@
-plugins/modules/grafana_dashboard.py validate-modules:invalid-argument-name
-tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py pep8:W291
-hacking/check_fragment.sh shebang
-hacking/find_grafana_versions.py shebang

--- a/tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py
+++ b/tests/unit/modules/grafana/grafana_plugin/test_grafana_plugin.py
@@ -21,7 +21,7 @@ Restart grafana after installing plugins . <service grafana-server restart>
 def run_command_install_zip():
     STDERR = ""
     STDOUT = """
-installing alexanderzobnin-grafana-zabbix @ 
+installing alexanderzobnin-grafana-zabbix @
 from: /home/grafana//alexanderzobnin-grafana-zabbix-v3.10.5-1-g2219691.zip
 into: /var/lib/grafana/plugins
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- increase number of returned releases by api to ensure the newest 3 majors are included
- refactor comparation of version numbers
  - work with multi digits major versions
  - compare versions as tulpe not as int
    - before: `10.0.13 (as_int: 10013) > 10.2.6 (as_int: 1026)` (older version is higher)
    - after: `10.0.13 (as_tulpe: (10, 0, 13)) < 10.2.6 (as_tulpe: (10, 2, 6))` (newer version is higher)
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
["9.5.18", "10.0.13"]
```

after:
```
["8.5.27", "9.5.18", "10.4.1"]
```