### PR TITLE
fix(lookup/grafana_dashboard): add custom certs verification logic

### DIFF
--- a/changelogs/fragments/356-lookup-dashboards-add-custom-certs-verification-logic.yml
+++ b/changelogs/fragments/356-lookup-dashboards-add-custom-certs-verification-logic.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - lookup - grafana_dashboards - add `validate_certs` and `ca_path` options to plugin for custom certs validation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This fix adds the `validate_certs`, `ca_path` options to the lookup plugin. Both parameters comply with the `get_url` functionality of ansible-core and provides additional utility to perform lookup of dashboards from Grafana instances that are configured with Self-Signed Certificates.

`validate_certs` option value defaults to `true` - following the pattern of `url` lookup plugin from the Core.

`ca_path` option value is set explicitly when using the plugin else defaults to `None`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #346

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Lookup Plugin for Grafana Dashboards

##### ADDITIONAL INFORMATION

Tested with a Grafana Docker image with Self-Signed Certificates as well as a local Certificate Authority. The Local CA along with a self-signed certificate is used to form a `chain.crt` and validated as `ca_path` option for the plugin.