### PR TITLE
handle errors with negative return code better

### DIFF
--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -81,7 +81,7 @@ def grafana_send_request(
         self._module.fail_json(failed=True, msg="Permission Denied")
     elif status_code < 0:
         self._module.fail_json(failed=True, msg=info["msg"])
-    elif status_code == 200:
+    elif status_code in [200, 202]:
         return self._module.from_json(resp.read())
     self._module.fail_json(
         failed=True,

--- a/plugins/module_utils/base.py
+++ b/plugins/module_utils/base.py
@@ -55,6 +55,7 @@ def grafana_required_together():
 def grafana_mutually_exclusive():
     return [["url_username", "grafana_api_key"]]
 
+
 def grafana_send_request(
     self, module, url, grafana_url, data=None, headers=None, method="GET"
 ):

--- a/plugins/modules/grafana_organization.py
+++ b/plugins/modules/grafana_organization.py
@@ -96,10 +96,8 @@ org:
                 zipCode: ""
 """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url, basic_auth_header
+from ansible.module_utils.urls import basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
 from ansible.module_utils.six.moves.urllib.parse import quote
 
@@ -117,59 +115,44 @@ class GrafanaOrgInterface(object):
         # }}}
         self.grafana_url = base.clean_url(module.params.get("url"))
 
-    def _send_request(self, url, data=None, headers=None, method="GET"):
-        if data is not None:
-            data = json.dumps(data, sort_keys=True)
-        if not headers:
-            headers = []
-
-        full_url = "{grafana_url}{path}".format(grafana_url=self.grafana_url, path=url)
-        resp, info = fetch_url(
-            self._module, full_url, data=data, headers=headers, method=method
-        )
-        status_code = info["status"]
-        if status_code == 404:
-            return None
-        elif status_code == 401:
-            self._module.fail_json(
-                failed=True,
-                msg="Unauthorized to perform action '%s' on '%s' header: %s"
-                % (method, full_url, self.headers),
-            )
-        elif status_code == 403:
-            self._module.fail_json(failed=True, msg="Permission Denied")
-        elif status_code == 200:
-            return self._module.from_json(resp.read())
-        if resp is None:
-            self._module.fail_json(
-                failed=True,
-                msg="Cannot connect to API Grafana %s" % info["msg"],
-                status=status_code,
-                url=info["url"],
-            )
-        else:
-            self._module.fail_json(
-                failed=True,
-                msg="Grafana Org API answered with HTTP %d" % status_code,
-                body=self._module.from_json(resp.read()),
-            )
-
     def get_actual_org(self, name):
         # https://grafana.com/docs/grafana/latest/http_api/org/#get-organization-by-name
         url = "/api/orgs/name/{name}".format(name=quote(name))
-        return self._send_request(url, headers=self.headers, method="GET")
+        return base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="GET",
+        )
 
     def create_org(self, name):
         # https://grafana.com/docs/http_api/org/#create-organization
         url = "/api/orgs"
         org = dict(name=name)
-        self._send_request(url, data=org, headers=self.headers, method="POST")
+        base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            data=org,
+            method="POST",
+        )
         return self.get_actual_org(name)
 
     def delete_org(self, org_id):
         # https://grafana.com/docs/http_api/org/#delete-organization
         url = "/api/orgs/{org_id}".format(org_id=org_id)
-        return self._send_request(url, headers=self.headers, method="DELETE")
+        return base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="DELETE",
+        )
 
 
 def setup_module_object():

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -225,7 +225,7 @@ class GrafanaSilenceInterface(object):
 
     def switch_organization(self, org_id):
         url = "/api/user/using/%d" % org_id
-        organizations = base.grafana_send_request(
+        base.grafana_send_request(
             self,
             module=self._module,
             url=url,

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -225,11 +225,25 @@ class GrafanaSilenceInterface(object):
 
     def switch_organization(self, org_id):
         url = "/api/user/using/%d" % org_id
-        self._send_request(url, headers=self.headers, method="POST")
+        organizations = base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="POST",
+        )
 
     def organization_by_name(self, org_name):
         url = "/api/user/orgs"
-        organizations = self._send_request(url, headers=self.headers, method="GET")
+        organizations = base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="GET",
+        )
         orga = next((org for org in organizations if org["name"] == org_name))
         if orga:
             return orga["orgId"]

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -154,10 +154,8 @@ user:
                 - false
 """
 
-import json
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url, basic_auth_header
+from ansible.module_utils.urls import basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
 from ansible.module_utils.six.moves.urllib.parse import quote
 
@@ -175,35 +173,6 @@ class GrafanaUserInterface(object):
         # }}}
         self.grafana_url = base.clean_url(module.params.get("url"))
 
-    def _send_request(self, url, data=None, headers=None, method="GET"):
-        if data is not None:
-            data = json.dumps(data, sort_keys=True)
-        if not headers:
-            headers = []
-
-        full_url = "{grafana_url}{path}".format(grafana_url=self.grafana_url, path=url)
-        resp, info = fetch_url(
-            self._module, full_url, data=data, headers=headers, method=method
-        )
-        status_code = info["status"]
-        if status_code == 404:
-            return None
-        elif status_code == 401:
-            self._module.fail_json(
-                failed=True,
-                msg="Unauthorized to perform action '%s' on '%s' header: %s"
-                % (method, full_url, self.headers),
-            )
-        elif status_code == 403:
-            self._module.fail_json(failed=True, msg="Permission Denied")
-        elif status_code == 200:
-            return self._module.from_json(resp.read())
-        self._module.fail_json(
-            failed=True,
-            msg="Grafana Users API answered with HTTP %d" % status_code,
-            body=self._module.from_json(resp.read()),
-        )
-
     def create_user(self, name, email, login, password):
         # https://grafana.com/docs/http_api/admin/#global-users
         if not password:
@@ -212,33 +181,69 @@ class GrafanaUserInterface(object):
             )
         url = "/api/admin/users"
         user = dict(name=name, email=email, login=login, password=password)
-        self._send_request(url, data=user, headers=self.headers, method="POST")
+        base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            data=user,
+            method="POST",
+        )
         return self.get_user_from_login(login)
 
     def get_user_from_login(self, login):
         # https://grafana.com/docs/grafana/latest/http_api/user/#get-single-user-by-usernamelogin-or-email
         url = "/api/users/lookup?loginOrEmail={login}".format(login=quote(login))
-        return self._send_request(url, headers=self.headers, method="GET")
+        return base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="GET",
+        )
 
     def update_user(self, user_id, email, name, login):
         # https://grafana.com/docs/http_api/user/#user-update
         url = "/api/users/{user_id}".format(user_id=user_id)
         user = dict(email=email, name=name, login=login)
-        self._send_request(url, data=user, headers=self.headers, method="PUT")
+        base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            data=user,
+            method="PUT",
+        )
         return self.get_user_from_login(login)
 
     def update_user_permissions(self, user_id, is_admin):
         # https://grafana.com/docs/http_api/admin/#permissions
         url = "/api/admin/users/{user_id}/permissions".format(user_id=user_id)
         permissions = dict(isGrafanaAdmin=is_admin)
-        return self._send_request(
-            url, data=permissions, headers=self.headers, method="PUT"
+        return base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            data=permissions,
+            method="PUT",
         )
 
     def delete_user(self, user_id):
         # https://grafana.com/docs/http_api/admin/#delete-global-user
         url = "/api/admin/users/{user_id}".format(user_id=user_id)
-        return self._send_request(url, headers=self.headers, method="DELETE")
+        return base.grafana_send_request(
+            self,
+            module=self._module,
+            url=url,
+            grafana_url=self.grafana_url,
+            headers=self.headers,
+            method="DELETE",
+        )
 
 
 def is_user_update_required(target_user, email, name, login, is_admin):


### PR DESCRIPTION
##### SUMMARY

In some cases the error returned by Grafana could have a status code `-1`, e.g.:

```
{'url': 'https://127.0.0.1:3000/api/users/lookup?loginOrEmail=username2', 'status': -1, 'msg': 'Request failed: <urlopen error [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1007)>'}
```

or

```
{'url': 'https://127.0.0.1/api/users/lookup?loginOrEmail=username2', 'status': -1, 'msg': 'Request failed: <urlopen error [Errno 111] Connection refused>'}
```

This initial commit fixes the problem for the grafana_user module. However this could happen in all modules. Therefore we should refactor out the send_request function in all modules and fix it there..

test-case:


1. run grafana 
```
> docker run -d -p 3000:3000 grafana/grafana:10.2.2
```

2. run the following playbook:
```
---
- hosts: localhost
  gather_facts: no
  vars:
    grafana_admin_user: grafana
    grafana_admin_password: grafana
    members:
      - uid: username
        description: 'User Name'
        email: 'user.name@whatever.com'
        password: 'hashed_passwd'
      - uid: username2
        description: 'User Name1'
        email: 'user.name2@whatever.com'
        password: 'hashed_passwd'
  tasks:
    - name: Create Grafana users
      community.grafana.grafana_user:
        url: "https://127.0.0.1"        # ## notice this is wrong
        url_username: "{{ grafana_admin_user }}"
        url_password: "{{ grafana_admin_password }}"
        login: "{{ member.uid }}"
        email: "{{ member.email }}"
        name: "{{ member.description }}"
        password: "{{ member.password }}"
        state: "present"
      loop: "{{ members }}"
      loop_control:
        loop_var: member

```

result:

```
> ansible-playbook test2.yml
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'
 __________________
< PLAY [localhost] >
 ------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

 _____________________________
< TASK [Create Grafana users] >
 -----------------------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'read'
failed: [localhost] (item={'uid': 'username', 'description': 'User Name', 'email': 'user.name@whatever.com', 'password': 'hashed_passwd'}) => {"ansible_loop_var": "member", "changed": false, "member": {"description": "User Name", "email": "user.name@whatever.com", "password": "hashed_passwd", "uid": "username"}, "module_stderr": "Traceback (most recent call last):\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969893.8799918-1346142-270361372579429/AnsiballZ_grafana_user.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969893.8799918-1346142-270361372579429/AnsiballZ_grafana_user.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969893.8799918-1346142-270361372579429/AnsiballZ_grafana_user.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.grafana.plugins.modules.grafana_user', init_globals=dict(_module_fqn='ansible_collections.community.grafana.plugins.modules.grafana_user', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_ctp3n329/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 323, in <module>\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_ctp3n329/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 292, in main\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_ctp3n329/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 221, in get_user_from_login\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_ctp3n329/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 204, in _send_request\nAttributeError: 'NoneType' object has no attribute 'read'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'read'
failed: [localhost] (item={'uid': 'username2', 'description': 'User Name1', 'email': 'user.name2@whatever.com', 'password': 'hashed_passwd'}) => {"ansible_loop_var": "member", "changed": false, "member": {"description": "User Name1", "email": "user.name2@whatever.com", "password": "hashed_passwd", "uid": "username2"}, "module_stderr": "Traceback (most recent call last):\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969894.262415-1346142-167829676315139/AnsiballZ_grafana_user.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969894.262415-1346142-167829676315139/AnsiballZ_grafana_user.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/segu/.ansible/tmp/ansible-tmp-1713969894.262415-1346142-167829676315139/AnsiballZ_grafana_user.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.grafana.plugins.modules.grafana_user', init_globals=dict(_module_fqn='ansible_collections.community.grafana.plugins.modules.grafana_user', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_vtib7xty/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 323, in <module>\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_vtib7xty/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 292, in main\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_vtib7xty/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 221, in get_user_from_login\n  File \"/tmp/ansible_community.grafana.grafana_user_payload_vtib7xty/ansible_community.grafana.grafana_user_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_user.py\", line 204, in _send_request\nAttributeError: 'NoneType' object has no attribute 'read'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
 ____________
< PLAY RECAP >
 ------------
        \   ^__^
         \  (oo)\_______
            (__)\       )\/\
                ||----w |
                ||     ||

localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
```


Fixes #333

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
