### PR TITLE
fix: grafana version sorting

### DIFF
--- a/changelogs/fragments/378-grafana-version-sorting.yml
+++ b/changelogs/fragments/378-grafana-version-sorting.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Fix grafana version sorting

--- a/hacking/find_grafana_versions.py
+++ b/hacking/find_grafana_versions.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         if major not in by_major.keys() or by_major[major]["as_tuple"] < as_tuple:
             by_major[major] = {"version": version, "as_tuple": as_tuple}
 
-    latest_3_majors = sorted(list(by_major.keys()))[:3]
+    latest_3_majors = sorted(list(by_major.keys()), reverse=True)[:3]
     latest_releases = [by_major[idx]["version"] for idx in latest_3_majors]
 
     print(json.dumps(latest_releases))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#377 reveals an error in the version sorting, so that grafana 11.0.0 is not one of the 3 current major versions

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
❯ python hacking/find_grafana_versions.py
["11.0.0", "10.4.4", "9.5.19"]
```
