### PR TITLE
fix(grafana_datasource): remove field apiVersion from return of current datasource

### DIFF
--- a/changelogs/fragments/396-datasource-diff-apiversion.yml
+++ b/changelogs/fragments/396-datasource-diff-apiversion.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove field `apiVersion` from return of current `grafana_datasource` for working diff

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -537,25 +537,29 @@ ES_VERSION_MAPPING = {
 
 
 def compare_datasources(new, current, compareSecureData=True):
-    if new["uid"] is None:
-        del current["uid"]
-        del new["uid"]
-    del current["typeLogoUrl"]
-    del current["id"]
-    if "version" in current:
-        del current["version"]
-    if "readOnly" in current:
-        del current["readOnly"]
-    if current["basicAuth"] is False:
-        if "basicAuthUser" in current:
-            del current["basicAuthUser"]
-    if "password" in current:
-        del current["password"]
-    if "basicAuthPassword" in current:
-        del current["basicAuthPassword"]
-    if current["type"] == "grafana-postgresql-datasource" and new["type"] == "postgres":
-        del current["type"]
-        del new["type"]
+    if new.get("uid") is None:
+        new.pop("uid", None)
+        current.pop("uid", None)
+
+    for field in [
+        "basicAuthPassword",
+        "id",
+        "password",
+        "readOnly",
+        "typeLogoUrl",
+        "version",
+    ]:
+        current.pop(field, None)
+
+    if not current.get("basicAuth", True):
+        current.pop("basicAuthUser", None)
+
+    if (
+        current.get("type") == "grafana-postgresql-datasource"
+        and new.get("type") == "postgres"
+    ):
+        new.pop("type", None)
+        current.pop("type", None)
 
     # check if secureJsonData should be compared
     if not compareSecureData:

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -542,6 +542,7 @@ def compare_datasources(new, current, compareSecureData=True):
         current.pop("uid", None)
 
     for field in [
+        "apiVersion",
         "basicAuthPassword",
         "id",
         "password",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove the apiVersion field from the return of the current datasource so that the comparison of the current and the new datasource works.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
