### PR TITLE
Feature: Add silence datasource

### DIFF
--- a/changelogs/fragments/605-silence-datastore-feature.yml
+++ b/changelogs/fragments/605-silence-datastore-feature.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add the ability to define which alertmanager datasource to target in grafana_silence

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -73,7 +73,7 @@ options:
     description:
       - Which alertmanager datasource to target
     type: str
-    required false
+    required: false
     default: grafana
   state:
     description:
@@ -251,8 +251,8 @@ class GrafanaSilenceInterface(object):
                 )
         
         if module.params.get("alertmanager_datasource", None):
-            self.alertmanager_path = (
-                self.datasource_by_name(module.params["alertmanager_datasource"])
+            self.alertmanager_path = self.datasource_by_name(
+              module.params["alertmanager_datasource"]
             )
 
     def _send_request(self, url, data=None, headers=None, method="GET"):

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -126,7 +126,6 @@ EXAMPLES = """
     alertmanager_datasource: exampleDS
     state: present
 
-
 - name: Delete a silence
   community.grafana.grafana_silence:
     grafana_url: "https://grafana.example.com"

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -69,6 +69,12 @@ options:
     type: list
     elements: dict
     required: true
+  alertmanager_datasource:
+    description:
+      - Which alertmanager datasource to target
+    type: str
+    required false
+    default: grafana
   state:
     description:
       - Delete the first occurrence of a silence with the same settings. Can be "absent" or "present".
@@ -103,6 +109,23 @@ EXAMPLES = """
         name: environment
         value: test
     state: present
+
+- name: Create a silence against a specific datasource
+  community.grafana.grafana_silence:
+    grafana_url: "https://grafana.example.com"
+    grafana_api_key: "{{ some_api_token_value }}"
+    comment: "a testcomment"
+    created_by: "me"
+    starts_at: "2029-07-29T08:45:45.000Z"
+    ends_at: "2029-07-29T08:55:45.000Z"
+    matchers:
+      - isEqual: true
+        isRegex: true
+        name: environment
+        value: test
+    alertmanager_datasource: exampleDS
+    state: present
+
 
 - name: Delete a silence
   community.grafana.grafana_silence:
@@ -196,6 +219,8 @@ class GrafanaSilenceInterface(object):
         self._module = module
         self.grafana_url = base.clean_url(module.params.get("url"))
         self.org_id = None
+        # Default here because you can't look up "grafana" DS via API
+        self.alertmanager_path = "grafana"
         # {{{ Authentication header
         self.headers = {"Content-Type": "application/json"}
         if module.params.get("grafana_api_key", None):
@@ -224,6 +249,11 @@ class GrafanaSilenceInterface(object):
                     failed=True,
                     msg="Silences API is available starting with Grafana v8",
                 )
+        
+        if module.params.get("alertmanager_datasource", None):
+            self.alertmanager_path = (
+                self.datasource_by_name(module.params["alertmanager_datasource"])
+            )
 
     def _send_request(self, url, data=None, headers=None, method="GET"):
         if data is not None:
@@ -268,6 +298,16 @@ class GrafanaSilenceInterface(object):
             failed=True, msg="Current user isn't member of organization: %s" % org_name
         )
 
+    def datasource_by_name(self, datasource_name):
+        url = f"/api/datasources/name/{datasource_name}"
+        datasource = self._send_request(url, headers=self.headers, method="GET")
+        if datasource:
+            return datasource["uid"]
+
+        return self._module.fail_json(
+            failed=True, msg=f"Datasource not found: {datasource_name}"
+        )
+
     def get_version(self):
         url = "/api/health"
         response = self._send_request(
@@ -280,7 +320,7 @@ class GrafanaSilenceInterface(object):
         raise GrafanaError("Failed to retrieve version from '%s'" % url)
 
     def create_silence(self, comment, created_by, starts_at, ends_at, matchers):
-        url = "/api/alertmanager/grafana/api/v2/silences"
+        url = f"/api/alertmanager/{self.alertmanager_path}/api/v2/silences"
         silence = dict(
             comment=comment,
             createdBy=created_by,
@@ -297,7 +337,7 @@ class GrafanaSilenceInterface(object):
         return response
 
     def get_silence(self, comment, created_by, starts_at, ends_at, matchers):
-        url = "/api/alertmanager/grafana/api/v2/silences"
+        url = f"/api/alertmanager/{self.alertmanager_path}/api/v2/silences"
 
         responses = self._send_request(url, headers=self.headers, method="GET")
 
@@ -313,21 +353,17 @@ class GrafanaSilenceInterface(object):
         return None
 
     def get_silence_by_id(self, silence_id):
-        url = "/api/alertmanager/grafana/api/v2/silence/{SilenceId}".format(
-            SilenceId=silence_id
-        )
+        url = f"/api/alertmanager/{self.alertmanager_path}/api/v2/silence/{silence_id}"
         response = self._send_request(url, headers=self.headers, method="GET")
         return response
 
     def get_silences(self):
-        url = "/api/alertmanager/grafana/api/v2/silences"
+        url = f"/api/alertmanager/{self.alertmanager_path}/api/v2/silences"
         response = self._send_request(url, headers=self.headers, method="GET")
         return response
 
     def delete_silence(self, silence_id):
-        url = "/api/alertmanager/grafana/api/v2/silence/{SilenceId}".format(
-            SilenceId=silence_id
-        )
+        url = f"/api/alertmanager/{self.alertmanager_path}/api/v2/silence/{silence_id}"
         response = self._send_request(url, headers=self.headers, method="DELETE")
         return response
 
@@ -352,6 +388,7 @@ argument_spec.update(
     org_name=dict(type="str"),
     skip_version_check=dict(type="bool", default=False),
     starts_at=dict(type="str", required=True),
+    alertmanager_datasource=dict(type=str),
     state=dict(type="str", choices=["present", "absent"], default="present"),
 )
 

--- a/plugins/modules/grafana_silence.py
+++ b/plugins/modules/grafana_silence.py
@@ -249,10 +249,10 @@ class GrafanaSilenceInterface(object):
                     failed=True,
                     msg="Silences API is available starting with Grafana v8",
                 )
-        
+
         if module.params.get("alertmanager_datasource", None):
             self.alertmanager_path = self.datasource_by_name(
-              module.params["alertmanager_datasource"]
+                module.params["alertmanager_datasource"]
             )
 
     def _send_request(self, url, data=None, headers=None, method="GET"):

--- a/tests/unit/modules/grafana/grafana_silence/test_grafana_silence.py
+++ b/tests/unit/modules/grafana/grafana_silence/test_grafana_silence.py
@@ -171,13 +171,13 @@ class GrafanaSilenceTest(TestCase):
 
     # create a new silence with alertmanager datasource defined
     @patch(
+        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.datasource_by_name"
+    )
+    @patch(
         "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.get_silence"
     )
     @patch(
         "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.get_version"
-    )
-    @patch(
-        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.datasource_by_name"
     )
     @patch(
         "ansible_collections.community.grafana.plugins.modules.grafana_silence.fetch_url"
@@ -306,10 +306,10 @@ class GrafanaSilenceTest(TestCase):
         self.assertEquals(result, {"message": "silence deleted"})
 
     @patch(
-        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.get_version"
+        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.datasource_by_name"
     )
     @patch(
-        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.datasource_by_name"
+        "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.get_version"
     )
     @patch(
         "ansible_collections.community.grafana.plugins.modules.grafana_silence.fetch_url"


### PR DESCRIPTION
##### SUMMARY
Grafana has the ability to support multiple alertmanager datasources.  Add the ability for grafana_silence to use user defined datasources (or default to grafana if none supplied).  

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_silence

##### ADDITIONAL INFORMATION
n/a
