### PR TITLE
test: replace more deprecated assertEquals

### DIFF
--- a/changelogs/fragments/406-python3.12.yml
+++ b/changelogs/fragments/406-python3.12.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "test: replace more deprecated `TestCase.assertEquals` to support Python 3.12"

--- a/tests/unit/modules/grafana/grafana_silence/test_grafana_silence.py
+++ b/tests/unit/modules/grafana/grafana_silence/test_grafana_silence.py
@@ -162,7 +162,7 @@ class GrafanaSilenceTest(TestCase):
             },
             method="POST",
         )
-        self.assertEquals(result, {"silenceID": "470b7116-8f06-4bb6-9e6c-6258aa92218e"})
+        self.assertEqual(result, {"silenceID": "470b7116-8f06-4bb6-9e6c-6258aa92218e"})
 
     @patch(
         "ansible_collections.community.grafana.plugins.modules.grafana_silence.GrafanaSilenceInterface.get_version"
@@ -208,4 +208,4 @@ class GrafanaSilenceTest(TestCase):
             },
             method="DELETE",
         )
-        self.assertEquals(result, {"message": "silence deleted"})
+        self.assertEqual(result, {"message": "silence deleted"})


### PR DESCRIPTION
##### SUMMARY
`TestCase.assertEquals` was deprecated and removed in Python 3.12.

Similar to #350, but for code that was added later.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
test