### PR TITLE
Allow managing dashboards in subfolders

### DIFF
--- a/changelogs/fragments/411-dashboard-subfolders.yml
+++ b/changelogs/fragments/411-dashboard-subfolders.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Allow creating dashboards in subfolders for `grafana_dashboard`

--- a/changelogs/fragments/411-dashboard-subfolders.yml
+++ b/changelogs/fragments/411-dashboard-subfolders.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Allow creating dashboards in subfolders for `grafana_dashboard`
+  - grafana_dashboard - allow creating dashboards in subfolders

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -263,7 +263,7 @@ def grafana_folder_exists(module, grafana_url, folder_name, parent_folder, heade
         folders = json.loads(r.read())
 
         for folder in folders:
-            if folder["title"] == folder_name:
+            if folder_name in (folder["title"], folder["uid"]):
                 return True, folder["id"]
     except Exception as e:
         raise GrafanaAPIException(e)

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -87,6 +87,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | org_id | no |
 | org_name | no |
 | overwrite | no |
+| parent_uid | no |
 | path | no |
 | slug | no |
 | state | no |

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -87,7 +87,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | org_id | no |
 | org_name | no |
 | overwrite | no |
-| parent_uid | no |
+| parent_folder | no |
 | path | no |
 | slug | no |
 | state | no |

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -328,6 +328,7 @@
         dashboard_id: "{{ dashboard.dashboard_id | default(omit) }}"
         dashboard_revision: "{{ dashboard.dashboard_revision | default(omit) }}"
         folder: "{{ dashboard.folder | default(omit) }}"
+        parent_folder: "{{ dashboard.parent_folder | default(omit) }}"
         org_id: "{{ dashboard.org_id | default(omit) }}"
         org_name: "{{ dashboard.org_name | default(omit) }}"
         overwrite: "{{ dashboard.overwrite | default(omit) }}"

--- a/tests/integration/targets/grafana_dashboard/site.yml
+++ b/tests/integration/targets/grafana_dashboard/site.yml
@@ -4,10 +4,11 @@
   vars_files:
     - defaults/main.yml
   module_defaults:
-    community.grafana.grafana_dashboard:
+    community.grafana.grafana_dashboard: &grafana_module_defaults
       grafana_url: "{{ grafana_url }}"
       grafana_user: "{{ grafana_username }}"
       grafana_password: "{{ grafana_password }}"
+    community.grafana.grafana_folder: *grafana_module_defaults
   tasks:
     - ansible.builtin.include_role:
         name: ../../grafana_dashboard

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
@@ -1,8 +1,7 @@
 ---
-- name: Create Dashboard from file | check mode | folder does not exist
+- name: Create Dashboard Folder Destination | check mode | folder does not exist
   community.grafana.grafana_dashboard:
     state: present
-    commit_message: Updated by ansible
     path: /tmp/dashboard.json
     overwrite: true
     folder: inexistent
@@ -15,10 +14,9 @@
       - dfff_result1.changed == false
       - "dfff_result1.msg == 'error : Dashboard folder \\'inexistent\\' does not exist.'"
 
-- name: Create Dashboard from file | run mode | folder does not exist
+- name: Create Dashboard Folder Destination | run mode | folder does not exist
   community.grafana.grafana_dashboard:
     state: present
-    commit_message: Updated by ansible
     path: /tmp/dashboard.json
     overwrite: true
     folder: inexistent
@@ -31,68 +29,64 @@
       - dfff_result2.changed == false
       - "dfff_result2.msg == 'error : Dashboard folder \\'inexistent\\' does not exist.'"
 
-- name: Create a dashboard in a folder
-  block:
-    - name: Create the original folder
-      community.grafana.grafana_folder:
-        title: parent_folder
-        state: present
-        url: "{{ grafana_url }}"
-        url_username: "{{ grafana_username }}"
-        url_password: "{{ grafana_password }}"
-      register: parent_folder
+- name: Create Dashboard Folder Destination | run mode | create parent folder
+  community.grafana.grafana_folder:
+    title: Parent
+    uid: parent_folder
+    state: present
+  check_mode: false
+  register: dfff_result_folder1
 
-    - name: Create the dashboard in the folder
-      community.grafana.grafana_dashboard:
-        grafana_url: "{{ grafana_url }}"
-        grafana_user: "{{ grafana_username }}"
-        grafana_password: "{{ grafana_password }}"
-        state: present
-        commit_message: Updated by ansible
-        path: /tmp/dashboard.json
-        overwrite: true
-        folder: parent_folder
-      check_mode: false
-      register: diff_result3
-      ignore_errors: true
-    - ansible.builtin.assert:
-        that:
-          - diff_result3.failed == false
-          - diff_result3.changed == true
+- name: Create Dashboard Folder Destination | run mode | create in parent folder
+  community.grafana.grafana_dashboard:
+    state: present
+    path: /tmp/dashboard.json
+    overwrite: true
+    folder: "{{ dfff_result_folder1.folder.uid }}"
+  check_mode: false
+  register: dfff_result3
+- ansible.builtin.assert:
+    that:
+      - dfff_result3.failed == false
+      - dfff_result3.changed == true
+      - dfff_result3.msg == 'Dashboard test created'
 
-- name: Create a dashboard in a subfolder
-  block:
-    - name: Create the subfolder
-      community.grafana.grafana_folder:
-        title: sub_folder
-        parent_uid: "{{ parent_folder.folder.uid }}"
-        state: present
-        url: "{{ grafana_url }}"
-        url_username: "{{ grafana_username }}"
-        url_password: "{{ grafana_password }}"
-      register: sub_folder
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: '{{ dfff_result3.uid }}'
 
-    - name: Create the dashboard in the subfolder
-      community.grafana.grafana_dashboard:
-        grafana_url: "{{ grafana_url }}"
-        grafana_user: "{{ grafana_username }}"
-        grafana_password: "{{ grafana_password }}"
-        state: present
-        commit_message: Updated by ansible
-        path: /tmp/dashboard.json
-        overwrite: true
-        folder: sub_folder
-        parent_uid: "{{ parent_folder.folder.uid }}"
-      check_mode: false
-      register: diff_result4
-      ignore_errors: true
-    - ansible.builtin.assert:
-        that:
-          - diff_result4.failed == false
-          - diff_result4.changed == true
-  rescue:
-    - name: Skip if we are running an older version of Grafana
-      ansible.builtin.assert:
-        that:
-          - sub_folder.msg | default ('') == 'Subfolder API is available starting Grafana v11'
-        fail_msg: "Failed to create dashboard in subfolder, for a separate reason than using an older Grafana. See above."
+- name: Create Dashboard Folder Destination | run mode | create subfolder
+  community.grafana.grafana_folder:
+    title: Subfolder
+    uid: sub_folder
+    parent_uid: "{{ dfff_result_folder1.folder.uid }}"
+    state: present
+  check_mode: false
+  register: dfff_result_folder2
+
+- name: Create Dashboard Folder Destination | run mode | create in subfolder
+  community.grafana.grafana_dashboard:
+    state: present
+    path: /tmp/dashboard.json
+    overwrite: true
+    folder: "{{ dfff_result_folder2.folder.uid }}"
+    parent_folder: "{{ dfff_result_folder1.folder.uid }}"
+  check_mode: false
+  register: dfff_result4
+- ansible.builtin.assert:
+    that:
+      - dfff_result4.failed == false
+      - dfff_result4.changed == true
+      - dfff_result4.msg == 'Dashboard test created'
+
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: '{{ dfff_result4.uid }}'
+
+- name: Create Dashboard Folder Destination | run mode | delete folders recursive
+  check_mode: false
+  community.grafana.grafana_folder:
+    name: "{{ dfff_result_folder1.folder.title }}"
+    state: absent

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
@@ -30,3 +30,69 @@
       - dfff_result2.failed == true
       - dfff_result2.changed == false
       - "dfff_result2.msg == 'error : Dashboard folder \\'inexistent\\' does not exist.'"
+
+- name: Create a dashboard in a folder
+  block:
+    - name: Create the original folder
+      community.grafana.grafana_folder:
+        title: parent_folder
+        state: present
+        url: "{{ grafana_url }}"
+        url_username: "{{ grafana_username }}"
+        url_password: "{{ grafana_password }}"
+      register: parent_folder
+
+    - name: Create the dashboard in the folder
+      community.grafana.grafana_dashboard:
+        grafana_url: "{{ grafana_url }}"
+        grafana_user: "{{ grafana_username }}"
+        grafana_password: "{{ grafana_password }}"
+        state: present
+        commit_message: Updated by ansible
+        path: /tmp/dashboard.json
+        overwrite: true
+        folder: parent_folder
+      check_mode: false
+      register: diff_result3
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - diff_result3.failed == false
+          - diff_result3.changed == true
+
+- name: Create a dashboard in a subfolder
+  block:
+    - name: Create the subfolder
+      community.grafana.grafana_folder:
+        title: sub_folder
+        parent_uid: "{{ parent_folder.folder.uid }}"
+        state: present
+        url: "{{ grafana_url }}"
+        url_username: "{{ grafana_username }}"
+        url_password: "{{ grafana_password }}"
+      register: sub_folder
+
+    - name: Create the dashboard in the subfolder
+      community.grafana.grafana_dashboard:
+        grafana_url: "{{ grafana_url }}"
+        grafana_user: "{{ grafana_username }}"
+        grafana_password: "{{ grafana_password }}"
+        state: present
+        commit_message: Updated by ansible
+        path: /tmp/dashboard.json
+        overwrite: true
+        folder: sub_folder
+        parent_uid: "{{ parent_folder.folder.uid }}"
+      check_mode: false
+      register: diff_result4
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - diff_result4.failed == false
+          - diff_result4.changed == true
+  rescue:
+    - name: Skip if we are running an older version of Grafana
+      ansible.builtin.assert:
+        that:
+          - sub_folder.msg | default ('') == 'Subfolder API is available starting Grafana v11'
+        fail_msg: "Failed to create dashboard in subfolder, for a separate reason than using an older Grafana. See above."

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
@@ -56,34 +56,46 @@
   vars:
     uid_to_delete: '{{ dfff_result3.uid }}'
 
-- name: Create Dashboard Folder Destination | run mode | create subfolder
+- name: Create Dashboard Folder Destination | run mode | check if v11 subfolder available
+  register: dfff_result_check_api
+  ignore_errors: true
+  check_mode: false
   community.grafana.grafana_folder:
-    title: Subfolder
-    uid: sub_folder
-    parent_uid: "{{ dfff_result_folder1.folder.uid }}"
-    state: present
-  check_mode: false
-  register: dfff_result_folder2
+    title: apitest
+    parent_uid: myparent
+    state: absent
 
-- name: Create Dashboard Folder Destination | run mode | create in subfolder
-  community.grafana.grafana_dashboard:
-    state: present
-    path: /tmp/dashboard.json
-    overwrite: true
-    folder: "{{ dfff_result_folder2.folder.uid }}"
-    parent_folder: "{{ dfff_result_folder1.folder.uid }}"
-  check_mode: false
-  register: dfff_result4
-- ansible.builtin.assert:
-    that:
-      - dfff_result4.failed == false
-      - dfff_result4.changed == true
-      - dfff_result4.msg == 'Dashboard test created'
+- name: Block for subfolder creation if api available
+  when: "dfff_result_check_api.msg | default('') != 'Subfolder API is available starting Grafana v11'"
+  block:
+    - name: Create Dashboard Folder Destination | run mode | create subfolder
+      community.grafana.grafana_folder:
+        title: Subfolder
+        uid: sub_folder
+        parent_uid: "{{ dfff_result_folder1.folder.uid }}"
+        state: present
+      check_mode: false
+      register: dfff_result_folder2
 
-- ansible.builtin.include_tasks:
-    file: delete-dashboard.yml
-  vars:
-    uid_to_delete: '{{ dfff_result4.uid }}'
+    - name: Create Dashboard Folder Destination | run mode | create in subfolder
+      community.grafana.grafana_dashboard:
+        state: present
+        path: /tmp/dashboard.json
+        overwrite: true
+        folder: "{{ dfff_result_folder2.folder.uid }}"
+        parent_folder: "{{ dfff_result_folder1.folder.uid }}"
+      check_mode: false
+      register: dfff_result4
+    - ansible.builtin.assert:
+        that:
+          - dfff_result4.failed == false
+          - dfff_result4.changed == true
+          - dfff_result4.msg == 'Dashboard test created'
+
+    - ansible.builtin.include_tasks:
+        file: delete-dashboard.yml
+      vars:
+        uid_to_delete: '{{ dfff_result4.uid }}'
 
 - name: Create Dashboard Folder Destination | run mode | delete folders recursive
   check_mode: false


### PR DESCRIPTION
##### SUMMARY

Since Grafana 11, it is possible to have dashboards in subfolders. This enables users to manage dashboards in those.

Fixes #410
Fixes #388 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_dashboard

##### To Maintainers

I am not quite sure how to increase the code coverage there, as, as far as I can tell, this is tested through the integration tests. Is that a problem? If so, any pointers?