### PR TITLE
grafana_dashboard: copy uid from data to payload

### DIFF
--- a/changelogs/fragments/416-dashboard-uid.yml
+++ b/changelogs/fragments/416-dashboard-uid.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - grafana_dashboard - add uid to payload

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -373,6 +373,7 @@ def grafana_create_dashboard(module, data):
     else:
         if data.get("uid"):
             uid = data["uid"]
+            payload["dashboard"]["uid"] = data["uid"]
         elif "uid" in payload["dashboard"]:
             uid = payload["dashboard"]["uid"]
         else:

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -52,7 +52,8 @@ options:
   uid:
     version_added: "1.0.0"
     description:
-      - uid of the dashboard to export when C(state) is C(export) or C(absent).
+      - Used to identify the dashboard when C(state) is C(export) or C(absent).
+      - When C(state) is C(present), this can be used to set the UID during dashboard creation.
     type: str
   path:
     description:

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -363,21 +363,15 @@ def grafana_create_dashboard(module, data):
     headers = grafana_headers(module, data)
 
     grafana_version = get_grafana_version(module, data["url"], headers)
+
     if grafana_version < 5:
-        if data.get("slug"):
-            uid = data["slug"]
-        elif "meta" in payload and "slug" in payload["meta"]:
-            uid = payload["meta"]["slug"]
-        else:
-            raise GrafanaMalformedJson("No slug found in json. Needed with grafana < 5")
+        uid = data.get("slug") or payload.get("meta", {}).get("slug")
+        if not uid:
+            raise GrafanaMalformedJson("No slug found in JSON. Needed with Grafana < 5")
     else:
+        uid = data.get("uid") or payload.get("dashboard", {}).get("uid")
         if data.get("uid"):
-            uid = data["uid"]
             payload["dashboard"]["uid"] = data["uid"]
-        elif "uid" in payload["dashboard"]:
-            uid = payload["dashboard"]["uid"]
-        else:
-            uid = None
 
     result = {}
 

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
@@ -3,9 +3,10 @@
   community.grafana.grafana_dashboard:
     state: present
     commit_message: Updated by ansible
-    dashboard_id: "6098"
+    dashboard_id: "1860"
     dashboard_revision: "1"
     overwrite: true
+    uid: "dfi"
   check_mode: true
   register: dfi_result1
 - ansible.builtin.assert:
@@ -13,60 +14,63 @@
       - dfi_result1.failed == false
       - dfi_result1.changed == true
       - dfi_result1.uid is not defined
-      - dfi_result1.msg == 'Dashboard Zabbix Host Status will be created'
+      - dfi_result1.msg == 'Dashboard Node Exporter Full will be created'
 
 - name: Create Dashboard from ID | run mode | dashboard does not exist
   community.grafana.grafana_dashboard:
     state: present
     commit_message: Updated by ansible
-    dashboard_id: "6098"
+    dashboard_id: "1860"
     dashboard_revision: "1"
     overwrite: true
+    uid: "dfi"
   check_mode: false
   register: dfi_result2
 - ansible.builtin.assert:
     that:
       - dfi_result2.failed == false
       - dfi_result2.changed == true
-      - dfi_result2.uid is defined
-      - dfi_result2.uid is string
-      - dfi_result2.msg == 'Dashboard Zabbix Host Status created'
+      - dfi_result2.uid is truthy
+      - dfi_result2.uid == 'dfi'
+      - dfi_result2.msg == 'Dashboard Node Exporter Full created'
 
 - name: Create Dashboard from ID | check mode | dashboard exists
   community.grafana.grafana_dashboard:
     state: present
     commit_message: Updated by ansible
-    dashboard_id: "6098"
+    dashboard_id: "1860"
     dashboard_revision: "1"
     overwrite: true
+    uid: "dfi"
   check_mode: true
   register: dfi_result3
 - ansible.builtin.assert:
     that:
       - dfi_result3.failed == false
       - dfi_result3.changed == false
-      - dfi_result3.uid is defined
-      - dfi_result3.uid is string
-      - dfi_result3.msg == 'Dashboard Zabbix Host Status unchanged.'
+      - dfi_result3.uid is truthy
+      - dfi_result3.uid == 'dfi'
+      - dfi_result3.msg == 'Dashboard Node Exporter Full unchanged.'
 
 - name: Create Dashboard from ID | run mode | dashboard exists
   community.grafana.grafana_dashboard:
     state: present
     commit_message: Updated by ansible
-    dashboard_id: "6098"
+    dashboard_id: "1860"
     dashboard_revision: "1"
     overwrite: true
+    uid: "dfi"
   check_mode: false
   register: dfi_result4
 - ansible.builtin.assert:
     that:
       - dfi_result4.failed == false
       - dfi_result4.changed == false
-      - dfi_result4.uid is defined
-      - dfi_result4.uid is string
-      - dfi_result4.msg == 'Dashboard Zabbix Host Status unchanged.'
+      - dfi_result4.uid is truthy
+      - dfi_result4.uid == 'dfi'
+      - dfi_result4.msg == 'Dashboard Node Exporter Full unchanged.'
 
-- ansible.builtin.include_tasks:
-    file: delete-dashboard.yml
-  vars:
-    uid_to_delete: '{{ dfi_result4.uid }}'
+# - ansible.builtin.include_tasks:
+#     file: delete-dashboard.yml
+#   vars:
+#     uid_to_delete: '{{ dfi_result4.uid }}'

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-from-id.yml
@@ -70,7 +70,7 @@
       - dfi_result4.uid == 'dfi'
       - dfi_result4.msg == 'Dashboard Node Exporter Full unchanged.'
 
-# - ansible.builtin.include_tasks:
-#     file: delete-dashboard.yml
-#   vars:
-#     uid_to_delete: '{{ dfi_result4.uid }}'
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: '{{ dfi_result4.uid }}'


### PR DESCRIPTION
##### SUMMARY
The "uid" module parameter wasn't send to the API and new dashboard was created instead instead of updated. 
This patch fixes it by copying uid from data to the payload


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard.py