### PR TITLE
fix(grafana_dashboard): fix change detection for dashboards in folders

### DIFF
--- a/changelogs/fragments/428-dashboard-change-detection.yml
+++ b/changelogs/fragments/428-dashboard-change-detection.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - grafana_dashboard - fix change detection for dashboards in folders

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -329,15 +329,17 @@ def is_grafana_dashboard_changed(payload, dashboard):
     if "version" in dashboard["dashboard"]:
         del dashboard["dashboard"]["version"]
 
+    # if folderId is not provided in dashboard,
+    # try getting the folderId from the dashboard metadata,
+    # otherwise set the default folderId
+    if "folderId" not in dashboard:
+        dashboard["folderId"] = dashboard["meta"].get("folderId", 0)
+
     # remove meta key if exists for compare
     if "meta" in dashboard:
         del dashboard["meta"]
     if "meta" in payload:
         del payload["meta"]
-
-    # if folderId is not provided in dashboard, set default folderId
-    if "folderId" not in dashboard:
-        dashboard["folderId"] = 0
 
     # Ignore dashboard ids since real identifier is uuid
     if "id" in dashboard["dashboard"]:

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-folder-destination.yml
@@ -37,7 +37,7 @@
   check_mode: false
   register: dfff_result_folder1
 
-- name: Create Dashboard Folder Destination | run mode | create in parent folder
+- name: Create Dashboard Folder Destination | run mode | create in parent folder | dashboard does not exist
   community.grafana.grafana_dashboard:
     state: present
     path: /tmp/dashboard.json
@@ -50,6 +50,20 @@
       - dfff_result3.failed == false
       - dfff_result3.changed == true
       - dfff_result3.msg == 'Dashboard test created'
+
+- name: Create Dashboard Folder Destination | run mode | create in parent folder | dashboard exists
+  community.grafana.grafana_dashboard:
+    state: present
+    path: /tmp/dashboard.json
+    overwrite: true
+    folder: "{{ dfff_result_folder1.folder.uid }}"
+  check_mode: false
+  register: dfff_result4
+- ansible.builtin.assert:
+    that:
+      - dfff_result4.failed == false
+      - dfff_result4.changed == false
+      - dfff_result4.msg == 'Dashboard test unchanged.'
 
 - ansible.builtin.include_tasks:
     file: delete-dashboard.yml
@@ -77,7 +91,7 @@
       check_mode: false
       register: dfff_result_folder2
 
-    - name: Create Dashboard Folder Destination | run mode | create in subfolder
+    - name: Create Dashboard Folder Destination | run mode | create in subfolder | dashboard does not exist
       community.grafana.grafana_dashboard:
         state: present
         path: /tmp/dashboard.json
@@ -85,12 +99,27 @@
         folder: "{{ dfff_result_folder2.folder.uid }}"
         parent_folder: "{{ dfff_result_folder1.folder.uid }}"
       check_mode: false
-      register: dfff_result4
+      register: dfff_result5
     - ansible.builtin.assert:
         that:
-          - dfff_result4.failed == false
-          - dfff_result4.changed == true
-          - dfff_result4.msg == 'Dashboard test created'
+          - dfff_result5.failed == false
+          - dfff_result5.changed == true
+          - dfff_result5.msg == 'Dashboard test created'
+
+    - name: Create Dashboard Folder Destination | run mode | create in subfolder | dashboard exists
+      community.grafana.grafana_dashboard:
+        state: present
+        path: /tmp/dashboard.json
+        overwrite: true
+        folder: "{{ dfff_result_folder2.folder.uid }}"
+        parent_folder: "{{ dfff_result_folder1.folder.uid }}"
+      check_mode: false
+      register: dfff_result6
+    - ansible.builtin.assert:
+        that:
+          - dfff_result6.failed == false
+          - dfff_result6.changed == false
+          - dfff_result6.msg == 'Dashboard test unchanged.'
 
     - ansible.builtin.include_tasks:
         file: delete-dashboard.yml


### PR DESCRIPTION
##### SUMMARY
For recent versions of grafana, change detection for dashboards in folders is broken. This is because the `folderId` in the API response from grafana is now in the `meta` section, not the `dashboard` section:

https://grafana.com/docs/grafana/latest/developers/http_api/dashboard/#get-dashboard-by-uid

This patch changes the behaviour of `is_grafana_dashboard_changed()` to look up the `folderId` from the `meta` section (if it exists) and copy it to the `dashboard` section so that the `if payload == dashboard` check will pass for dashboards in folders that don't have the default `folderId` of 0.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ADDITIONAL INFORMATION
There is an included integration test which works against this patch, but fails against the main branch.

You can use a local ansible playbook to reproduce the issue also:

```
- name: Test grafana
  hosts: localhost
  tasks:
    - name: Create dashboard without a folder
      community.grafana.grafana_dashboard:
        grafana_url: "http://localhost:3000"
        uid: test-dashboard-without-folder
        dashboard_id: "1860"
        dashboard_revision: "37"
        overwrite: "true"
        state: "present"

    - name: Create dashboard with a folder
      community.grafana.grafana_dashboard:
        grafana_url: "http://localhost:3000"
        uid: test-dashboard-with-folder
        dashboard_id: "13659"
        dashboard_revision: "1"
        folder: "Test"
        overwrite: "true"
        state: "present"
```

If you run the above playbook twice, the second time the playbook runs you will see this the second task reports a change even though the dashboard is identical:

```
PLAY [Test grafana]

TASK [Create dashboard without a folder] 
ok: [localhost]

TASK [Create dashboard with a folder] 
changed: [localhost]

PLAY RECAP 
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```