### PR TITLE
feat(grafana_dashboard): allow imported dashboards to be renamed

### DIFF
--- a/changelogs/fragments/429-dashboard-title.yml
+++ b/changelogs/fragments/429-dashboard-title.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - grafana_dashboard - allow imported dashboards to be renamed

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -62,6 +62,12 @@ options:
       - Used to identify the dashboard when C(state) is C(export) or C(absent).
       - When C(state) is C(present), this can be used to set the UID during dashboard creation.
     type: str
+  name:
+    description:
+      - A new title to rename the imported Grafana dashboard to.
+    type: str
+    aliases: [ title ]
+    version_added: "2.3.0"
   path:
     description:
       - The path to the json file containing the Grafana dashboard to import or export.
@@ -391,6 +397,10 @@ def grafana_create_dashboard(module, data):
         if data.get("uid"):
             payload["dashboard"]["uid"] = data["uid"]
 
+    if data.get("name"):
+        # rename dashboard if user has provided a custom name
+        payload["dashboard"]["title"] = data["name"]
+
     result = {}
 
     # test if the folder exists
@@ -632,6 +642,7 @@ def main():
         folder=dict(type="str", default="General"),
         parent_folder=dict(type="str"),
         uid=dict(type="str"),
+        name=dict(type="str", aliases=["title"]),
         slug=dict(type="str"),
         path=dict(aliases=["dashboard_url"], type="str"),
         dashboard_id=dict(type="str"),

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -92,6 +92,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | slug | no |
 | state | no |
 | uid | no |
+| name | no |
 | [**grafana_organization_users**](https://docs.ansible.com/ansible/latest/collections/community/grafana/grafana_organization_user_module.html) |
 | login | yes |
 | org_id | no |

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -336,6 +336,7 @@
         slug: "{{ dashboard.slug | default(omit) }}"
         state: "{{ dashboard.state | default(omit) }}"
         uid: "{{ dashboard.uid | default(omit) }}"
+        name: "{{ dashboard.name | default(omit) }}"
       loop: "{{ grafana_dashboards }}"
       loop_control: {loop_var: dashboard}
       tags: [dashboard, molecule-idempotence-notest]

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-rename.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-rename.yml
@@ -1,0 +1,160 @@
+---
+- name: Create dashboard from ID with custom name | check mode | dashboard does not exist
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "7587"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Different Name"
+  check_mode: true
+  register: dfi_result1
+- ansible.builtin.assert:
+    that:
+      - dfi_result1.failed == false
+      - dfi_result1.changed == true
+      - dfi_result1.uid is not defined
+      - dfi_result1.msg == 'Dashboard Different Name will be created'
+
+- name: Create dashboard from ID with custom name | run mode | dashboard does not exist
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "7587"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Different Name"
+  check_mode: false
+  register: dfi_result2
+- ansible.builtin.assert:
+    that:
+      - dfi_result2.failed == false
+      - dfi_result2.changed == true
+      - dfi_result2.uid is truthy
+      - dfi_result2.uid == 'dfi'
+      - dfi_result2.msg == 'Dashboard Different Name created'
+
+- name: Create dashboard from ID with custom name | check mode | dashboard exists
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "7587"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Different Name"
+  check_mode: true
+  register: dfi_result3
+- ansible.builtin.assert:
+    that:
+      - dfi_result3.failed == false
+      - dfi_result3.changed == false
+      - dfi_result3.uid is truthy
+      - dfi_result3.uid == 'dfi'
+      - dfi_result3.msg == 'Dashboard Different Name unchanged.'
+
+- name: Create dashboard from ID with custom name | run mode | dashboard exists
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "7587"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Different Name"
+  check_mode: false
+  register: dfi_result4
+- ansible.builtin.assert:
+    that:
+      - dfi_result4.failed == false
+      - dfi_result4.changed == false
+      - dfi_result4.uid is truthy
+      - dfi_result4.uid == 'dfi'
+      - dfi_result4.msg == 'Dashboard Different Name unchanged.'
+
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: "{{ dfi_result4.uid }}"
+
+- name: Create dashboard from ID with default name | run mode | dashboard does not exist
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "9578"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+  check_mode: false
+  register: dfi_result5
+- ansible.builtin.assert:
+    that:
+      - dfi_result5.failed == false
+      - dfi_result5.changed == true
+      - dfi_result5.uid is truthy
+      - dfi_result5.uid == 'dfi'
+      - dfi_result5.msg == 'Dashboard Alertmanager created'
+
+- name: Rename existing dashboard | check mode | dashboard has original name
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "9578"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Renamed"
+  check_mode: true
+  register: dfi_result6
+- ansible.builtin.assert:
+    that:
+      - dfi_result6.failed == false
+      - dfi_result6.changed == true
+      - dfi_result6.uid is truthy
+      - dfi_result6.uid == 'dfi'
+      - dfi_result6.msg == 'Dashboard Renamed will be updated'
+
+- name: Rename existing dashboard | run mode | dashboard has original name
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "9578"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Renamed"
+  check_mode: false
+  register: dfi_result7
+- ansible.builtin.assert:
+    that:
+      - dfi_result7.failed == false
+      - dfi_result7.changed == true
+      - dfi_result7.uid is truthy
+      - dfi_result7.uid == 'dfi'
+      - dfi_result7.msg == 'Dashboard Renamed updated'
+
+- name: Rename existing dashboard | run mode | dashboard has been renamed
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "9578"
+    dashboard_revision: "1"
+    overwrite: true
+    uid: "dfi"
+    name: "Renamed"
+  check_mode: false
+  register: dfi_result8
+- ansible.builtin.assert:
+    that:
+      - dfi_result8.failed == false
+      - dfi_result8.changed == false
+      - dfi_result8.uid is truthy
+      - dfi_result8.uid == 'dfi'
+      - dfi_result8.msg == 'Dashboard Renamed unchanged.'
+
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: "{{ dfi_result8.uid }}"

--- a/tests/integration/targets/grafana_dashboard/tasks/main.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/main.yml
@@ -7,6 +7,10 @@
   ansible.builtin.include_tasks:
     file: dashboard-from-id.yml
 
+- name: Create dashboard with custom name
+  ansible.builtin.include_tasks:
+    file: dashboard-rename.yml
+
 - name: Create dashboard from file and export
   ansible.builtin.include_tasks:
     file: dashboard-from-file-export.yml


### PR DESCRIPTION
##### SUMMARY
This feature allows users to rename public dashboards downloaded from the grafana website, by setting the new optional `name` attribute which is present on many of the other grafana modules (e.g grafana_folder, grafana_datasource). 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ADDITIONAL INFORMATION
See included integration test for some examples of how to use, or this simple ansible playbook:

```
- name: Test grafana
  hosts: localhost
  tasks:
    - name: Create dashboard with a title
      community.grafana.grafana_dashboard:
        grafana_url: "http://localhost:3000"
        uid: test-dashboard-name
        name: Custom dashboard name
        dashboard_id: "1860"
        dashboard_revision: "37"
        overwrite: "true"
        state: "present"
```
