### PR TITLE
feat(grafana_dashboard): allow dashboard input variables to be set

### DIFF
--- a/changelogs/fragments/430-dashboard-inputs.yml
+++ b/changelogs/fragments/430-dashboard-inputs.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - grafana_dashboard - allow dashboard input variables to be set

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -85,6 +85,12 @@ options:
     default: '1'
     version_added: "1.0.0"
     type: str
+  inputs:
+    description:
+      - Set replacement values for dashboard input variables
+      - The dictionary key is the input name and the value is the input value
+    version_added: "2.3.0"
+    type: dict
   commit_message:
     description:
       - Set a commit message for the version history.
@@ -128,6 +134,15 @@ EXAMPLES = """
     folder: myteam
     dashboard_url: https://grafana.com/api/dashboards/6098/revisions/1/download
 
+- name: Import Grafana dashboard Node Exporter Full and set value for an input
+  community.grafana.grafana_dashboard:
+    grafana_url: http://grafana.company.com
+    grafana_api_key: "{{ grafana_api_key }}"
+    dashboard_id: 1860
+    dashboard_revision: 40
+    inputs:
+      DS_PROMETHEUS: DatasourceName
+
 - name: Export dashboard
   community.grafana.grafana_dashboard:
     grafana_url: http://grafana.company.com
@@ -148,6 +163,7 @@ uid:
   sample: 000000063
 """
 
+import copy
 import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -341,6 +357,27 @@ def is_grafana_dashboard_changed(payload, dashboard):
     if "meta" in payload:
         del payload["meta"]
 
+    # remove elements which are stripped by the import api
+    for key in ["__inputs", "__elements", "__requires"]:
+        if key in dashboard["dashboard"]:
+            del dashboard["dashboard"][key]
+        if key in payload["dashboard"]:
+            del payload["dashboard"][key]
+
+    if "inputs" in payload:
+        # ignore inputs for compare
+        dashboard["inputs"] = payload["inputs"]
+
+        # replace inputs in payload with actual values
+        payload_string = json.dumps(payload)
+        for input_var in payload["inputs"]:
+            if "name" not in input_var or "value" not in input_var:
+                continue
+            payload_string = payload_string.replace(
+                "${" + input_var["name"] + "}", input_var["value"]
+            )
+        payload = json.loads(payload_string)
+
     # Ignore dashboard ids since real identifier is uuid
     if "id" in dashboard["dashboard"]:
         del dashboard["dashboard"]["id"]
@@ -393,6 +430,24 @@ def grafana_create_dashboard(module, data):
         if data.get("uid"):
             payload["dashboard"]["uid"] = data["uid"]
 
+    # set dashboard inputs
+    api_endpoint = "db"
+    if data["inputs"] is not None:
+        inputs = []
+        for input_var in copy.deepcopy(payload["dashboard"].get("__inputs", [])):
+            if input_var.get("name") is None:
+                continue
+            if input_var["name"] in data["inputs"]:
+                # user has overriden input value
+                input_var["value"] = data["inputs"].get(input_var["name"])
+                inputs.append(input_var)
+            elif "value" in input_var:
+                # use default value for input
+                inputs.append(input_var)
+        if len(inputs) >= 1:
+            api_endpoint = "import"
+            payload["inputs"] = inputs
+
     result = {}
 
     # test if the folder exists
@@ -428,7 +483,10 @@ def grafana_create_dashboard(module, data):
         )
 
     if dashboard_exists is True:
-        grafana_dashboard_changed = is_grafana_dashboard_changed(payload, dashboard)
+        # pass a copy of payload so that the original isn't modified by this function
+        grafana_dashboard_changed = is_grafana_dashboard_changed(
+            copy.deepcopy(payload), dashboard
+        )
 
         if grafana_dashboard_changed:
             if module.check_mode:
@@ -446,7 +504,7 @@ def grafana_create_dashboard(module, data):
 
             r, info = fetch_url(
                 module,
-                "%s/api/dashboards/db" % data["url"],
+                "%s/api/dashboards/%s" % (data["url"], api_endpoint),
                 data=json.dumps(payload),
                 headers=headers,
                 method="POST",
@@ -486,7 +544,7 @@ def grafana_create_dashboard(module, data):
 
         r, info = fetch_url(
             module,
-            "%s/api/dashboards/db" % data["url"],
+            "%s/api/dashboards/%s" % (data["url"], api_endpoint),
             data=json.dumps(payload),
             headers=headers,
             method="POST",
@@ -640,6 +698,7 @@ def main():
         dashboard_revision=dict(type="str", default="1"),
         overwrite=dict(type="bool", default=False),
         commit_message=dict(type="str"),
+        inputs=dict(type="dict"),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -84,6 +84,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | dashboard_id | no |
 | dashboard_revision | no |
 | folder | no |
+| inputs | no |
 | org_id | no |
 | org_name | no |
 | overwrite | no |

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -329,6 +329,7 @@
         dashboard_revision: "{{ dashboard.dashboard_revision | default(omit) }}"
         folder: "{{ dashboard.folder | default(omit) }}"
         parent_folder: "{{ dashboard.parent_folder | default(omit) }}"
+        inputs: "{{ dashboard.inputs | default(omit) }}"
         org_id: "{{ dashboard.org_id | default(omit) }}"
         org_name: "{{ dashboard.org_name | default(omit) }}"
         overwrite: "{{ dashboard.overwrite | default(omit) }}"

--- a/tests/integration/targets/grafana_dashboard/tasks/dashboard-inputs.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/dashboard-inputs.yml
@@ -1,0 +1,84 @@
+---
+- name: Create Dashboard with inputs | check mode | dashboard does not exist
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "405"
+    dashboard_revision: "8"
+    inputs:
+      DS_PROMETHEUS: Prometheus
+    overwrite: true
+    uid: "dfi"
+  check_mode: true
+  register: dfi_result1
+- ansible.builtin.assert:
+    that:
+      - dfi_result1.failed == false
+      - dfi_result1.changed == true
+      - dfi_result1.uid is not defined
+      - dfi_result1.msg == 'Dashboard Node Exporter Server Metrics will be created'
+
+- name: Create Dashboard with inputs | run mode | dashboard does not exist
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "405"
+    dashboard_revision: "8"
+    inputs:
+      DS_PROMETHEUS: Prometheus
+    overwrite: true
+    uid: "dfi"
+  check_mode: false
+  register: dfi_result2
+- ansible.builtin.assert:
+    that:
+      - dfi_result2.failed == false
+      - dfi_result2.changed == true
+      - dfi_result2.uid is truthy
+      - dfi_result2.uid == 'dfi'
+      - dfi_result2.msg == 'Dashboard Node Exporter Server Metrics created'
+
+- name: Create Dashboard with inputs | check mode | dashboard exists
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "405"
+    dashboard_revision: "8"
+    inputs:
+      DS_PROMETHEUS: Prometheus
+    overwrite: true
+    uid: "dfi"
+  check_mode: true
+  register: dfi_result3
+- ansible.builtin.assert:
+    that:
+      - dfi_result3.failed == false
+      - dfi_result3.changed == false
+      - dfi_result3.uid is truthy
+      - dfi_result3.uid == 'dfi'
+      - dfi_result3.msg == 'Dashboard Node Exporter Server Metrics unchanged.'
+
+- name: Create Dashboard with inputs | run mode | dashboard exists
+  community.grafana.grafana_dashboard:
+    state: present
+    commit_message: Updated by ansible
+    dashboard_id: "405"
+    dashboard_revision: "8"
+    inputs:
+      DS_PROMETHEUS: Prometheus
+    overwrite: true
+    uid: "dfi"
+  check_mode: false
+  register: dfi_result4
+- ansible.builtin.assert:
+    that:
+      - dfi_result4.failed == false
+      - dfi_result4.changed == false
+      - dfi_result4.uid is truthy
+      - dfi_result4.uid == 'dfi'
+      - dfi_result4.msg == 'Dashboard Node Exporter Server Metrics unchanged.'
+
+- ansible.builtin.include_tasks:
+    file: delete-dashboard.yml
+  vars:
+    uid_to_delete: "{{ dfi_result4.uid }}"

--- a/tests/integration/targets/grafana_dashboard/tasks/main.yml
+++ b/tests/integration/targets/grafana_dashboard/tasks/main.yml
@@ -7,6 +7,10 @@
   ansible.builtin.include_tasks:
     file: dashboard-from-id.yml
 
+- name: Create dashboard with inputs
+  ansible.builtin.include_tasks:
+    file: dashboard-inputs.yml
+
 - name: Create dashboard from file and export
   ansible.builtin.include_tasks:
     file: dashboard-from-file-export.yml


### PR DESCRIPTION
##### SUMMARY
This feature allows users to set dashboard inputs when creating/updating a dashboard by providing a dictionary of input names and values with the new optional `inputs` attribute.

Fixes #329 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
grafana_dashboard

##### ADDITIONAL INFORMATION
See included integration test for some examples of how to use, or this simple ansible playbook:

```
- name: Test grafana
  hosts: localhost
  tasks:
    - name: Create dashboard with inputs
      community.grafana.grafana_dashboard:
        grafana_url: "http://localhost:3000"
        uid: test-dashboard-inputs
        dashboard_id: "1860"
        dashboard_revision: "40"
        inputs:
          DS_PROMETHEUS: prometheus
        overwrite: "true"
        state: "present"
```
