### PR TITLE
feat: [grafana_datasource] add support for sentry datasource

### DIFF
--- a/changelogs/fragments/437-add-datasource-type-sentry.yml
+++ b/changelogs/fragments/437-add-datasource-type-sentry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Add support for Sentry datasource type (https://grafana.com/grafana/plugins/grafana-sentry-datasource/)

--- a/changelogs/fragments/437-add-datasource-type-sentry.yml
+++ b/changelogs/fragments/437-add-datasource-type-sentry.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - Add support for Sentry datasource type (https://grafana.com/grafana/plugins/grafana-sentry-datasource/)

--- a/changelogs/fragments/441-add-datasource-type-sentry.yml
+++ b/changelogs/fragments/441-add-datasource-type-sentry.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - grafana_datasource - add support for Sentry datasource type

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -50,11 +50,12 @@ options:
     - tempo
     - quickwit-quickwit-datasource
     - alertmanager
+    - grafana-sentry-datasource
     type: str
   ds_url:
     description:
     - The URL of the datasource.
-    - Required when C(state=present).
+    - Required when C(state=present), except when using sentry_url.
     type: str
   access:
     description:
@@ -351,6 +352,11 @@ options:
     - Password for Zabbix API
     required: false
     type: str
+  sentry_url:
+    description:
+    - Base URL for Sentry API. Required when using sentry datasource.
+    required: false
+    type: str
   additional_json_data:
     description:
     - Defined data is used for datasource jsonData
@@ -480,6 +486,19 @@ EXAMPLES = """
     basic_auth_user: "thruk-user"
     basic_auth_password: "******"
 
+- name: grafana - update sentry datasource
+  community.grafana.grafana_datasource:
+    name: sentry
+    grafana_url: "https://grafana.company.com"
+    grafana_user: "admin"
+    grafana_password: "xxxxxx"
+    ds_type: grafana-sentry-datasource
+    sentry_url: https://sentry.io/
+    additional_json_data:
+      orgSlug: your-org
+    additional_secure_json_data:
+      authToken: supersecret
+
 # handle secure data - workflow example
 # this will create/update the datasource but dont update the secure data on updates
 # so you can assert if all tasks are changed=False
@@ -567,6 +586,7 @@ def compare_datasources(new, current, compareSecureData=True):
         "readOnly",
         "typeLogoUrl",
         "version",
+        "sentry_url",
     ]:
         current.pop(field, None)
 
@@ -726,6 +746,12 @@ def get_datasource_payload(data, org_id=None):
             secure_json_data["accessKey"] = data.get("aws_access_key")
             secure_json_data["secretKey"] = data.get("aws_secret_key")
 
+    if data["ds_type"] == "grafana-sentry-datasource":
+        json_data["url"] = data["sentry_url"]
+        payload["url"] = ""
+        if "authToken" not in secure_json_data:
+            raise KeyError("The key 'authToken' is required under additional_secure_json_data for Sentry datasources")
+
     payload["jsonData"] = json_data
     payload["secureJsonData"] = secure_json_data
     return payload
@@ -839,6 +865,7 @@ def setup_module_object():
                 "tempo",
                 "quickwit-quickwit-datasource",
                 "alertmanager",
+                "grafana-sentry-datasource",
             ]
         ),
         ds_url=dict(type="str"),
@@ -925,6 +952,7 @@ def setup_module_object():
         azure_tenant=dict(type="str"),
         azure_client=dict(type="str"),
         azure_secret=dict(type="str", no_log=True),
+        sentry_url=dict(type="str"),
         zabbix_user=dict(type="str"),
         zabbix_password=dict(type="str", no_log=True),
         additional_json_data=dict(type="dict", default={}, required=False),
@@ -945,7 +973,7 @@ def setup_module_object():
             ["org_id", "org_name"],
         ],
         required_if=[
-            ["state", "present", ["ds_type", "ds_url"]],
+            ["state", "present", ["ds_type"]],
             ["ds_type", "opentsdb", ["tsdb_version", "tsdb_resolution"]],
             ["ds_type", "influxdb", ["database"]],
             [
@@ -960,6 +988,7 @@ def setup_module_object():
             ["es_version", "60", ["max_concurrent_shard_requests"]],
             ["es_version", "70", ["max_concurrent_shard_requests"]],
         ],
+        required_one_of=[["ds_url", "sentry_url"]],
     )
     return module
 

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -565,7 +565,6 @@ from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
 
-
 ES_VERSION_MAPPING = {
     "7.7+": "7.7.0",
     "7.10+": "7.10.0",
@@ -750,7 +749,9 @@ def get_datasource_payload(data, org_id=None):
         json_data["url"] = data["sentry_url"]
         payload["url"] = ""
         if "authToken" not in secure_json_data:
-            raise KeyError("The key 'authToken' is required under additional_secure_json_data for Sentry datasources")
+            raise KeyError(
+                "The key 'authToken' is required under additional_secure_json_data for Sentry datasources"
+            )
 
     payload["jsonData"] = json_data
     payload["secureJsonData"] = secure_json_data
@@ -974,6 +975,7 @@ def setup_module_object():
         ],
         required_if=[
             ["state", "present", ["ds_type"]],
+            ["state", "present", ["ds_url", "sentry_url"], True],
             ["ds_type", "opentsdb", ["tsdb_version", "tsdb_resolution"]],
             ["ds_type", "influxdb", ["database"]],
             [
@@ -988,7 +990,6 @@ def setup_module_object():
             ["es_version", "60", ["max_concurrent_shard_requests"]],
             ["es_version", "70", ["max_concurrent_shard_requests"]],
         ],
-        required_one_of=[["ds_url", "sentry_url"]],
     )
     return module
 

--- a/roles/grafana/README.md
+++ b/roles/grafana/README.md
@@ -55,6 +55,7 @@ Configure Grafana organizations, dashboards, folders, datasources, teams and use
 | org_id | no |
 | org_name | no |
 | password | no |
+| sentry_url | no |
 | sslmode | no |
 | state | no |
 | time_field | no |

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -181,6 +181,7 @@
         org_id: "{{ datasource.org_id | default(omit) }}"
         org_name: "{{ datasource.org_name | default(omit) }}"
         password: "{{ datasource.password | default(omit) }}"
+        sentry_url: "{{ datasource.sentry_user | default(omit) }}"
         sslmode: "{{ datasource.sslmode | default(omit) }}"
         state: "{{ datasource.state | default(omit) }}"
         time_field: "{{ datasource.time_field | default(omit) }}"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -181,7 +181,7 @@
         org_id: "{{ datasource.org_id | default(omit) }}"
         org_name: "{{ datasource.org_name | default(omit) }}"
         password: "{{ datasource.password | default(omit) }}"
-        sentry_url: "{{ datasource.sentry_user | default(omit) }}"
+        sentry_url: "{{ datasource.sentry_url | default(omit) }}"
         sslmode: "{{ datasource.sslmode | default(omit) }}"
         state: "{{ datasource.state | default(omit) }}"
         time_field: "{{ datasource.time_field | default(omit) }}"

--- a/tests/integration/targets/grafana_datasource/tasks/errors.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/errors.yml
@@ -1,8 +1,9 @@
 ---
-- name: Create datasource without `ds_type` and `ds_url` (expect failure)
+- name: Create datasource without `ds_type` (expect failure)
   register: result
   community.grafana.grafana_datasource:
     name: datasource-postgres
+    ds_url: postgres:5432 
   ignore_errors: true
 
 - ansible.builtin.debug:
@@ -12,4 +13,20 @@
     that:
       - not result.changed
       - result.failed
-      - "result.msg == 'state is present but all of the following are missing: ds_type, ds_url'"
+      - "result.msg == 'state is present but all of the following are missing: ds_type'"
+
+- name: Create datasource without `ds_url` (expect failure)
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-postgres
+    ds_type: postgres
+  ignore_errors: true
+
+- ansible.builtin.debug:
+    var: result
+
+- ansible.builtin.assert:
+    that:
+      - not result.changed
+      - result.failed
+      - "result.msg == 'state is present but any of the following are missing: ds_url, sentry_url'"

--- a/tests/integration/targets/grafana_datasource/tasks/main.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/main.yml
@@ -14,3 +14,4 @@
     - redis
     - azure
     - uid
+    - sentry

--- a/tests/integration/targets/grafana_datasource/tasks/sentry.yml
+++ b/tests/integration/targets/grafana_datasource/tasks/sentry.yml
@@ -1,0 +1,98 @@
+---
+- name: Create sentry datasource
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-sentry
+    org_id: "1"
+    ds_type: grafana-sentry-datasource
+    sentry_url: https://sentry.io
+    additional_json_data:
+      orgSlug: my-organization
+    additional_secure_json_data:
+      authToken: "foo"
+
+- ansible.builtin.debug:
+    var: result
+
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - not result.datasource.isDefault
+      - result.datasource.jsonData.url == 'https://sentry.io'
+      - result.datasource.name == 'datasource-sentry'
+      - result.datasource.orgId == 1
+      - ('password' not in result.datasource) or (result.datasource.password == '')
+      - result.datasource.type == 'grafana-sentry-datasource'
+      - result.datasource.url == ''
+      - result.datasource.user == ''
+      - not result.datasource.withCredentials
+      - result.msg == 'Datasource datasource-sentry created'
+
+- name: Create sentry datasource (idempotency)
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-sentry
+    org_id: "1"
+    ds_type: grafana-sentry-datasource
+    sentry_url: https://sentry.io
+    additional_json_data:
+      orgSlug: my-organization
+    additional_secure_json_data:
+      authToken: "foo"
+
+- ansible.builtin.debug:
+    var: result
+
+- ansible.builtin.assert:
+    that:
+      - not result.changed
+
+- name: Update Sentry datasource
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-sentry
+    org_id: "1"
+    ds_type: grafana-sentry-datasource
+    sentry_url: https://sentry.io
+    additional_json_data:
+      orgSlug: my-organization-updated
+    additional_secure_json_data:
+      authToken: "foo"
+
+- ansible.builtin.debug:
+    var: result
+
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - not result.datasource.isDefault
+      - result.datasource.jsonData.url == 'https://sentry.io'
+      - result.datasource.jsonData.orgSlug == 'my-organization-updated'
+      - result.datasource.name == 'datasource-sentry'
+      - result.datasource.orgId == 1
+      - ('password' not in result.datasource) or (result.datasource.password == '')
+      - result.datasource.type == 'grafana-sentry-datasource'
+      - result.datasource.url == ''
+      - result.datasource.user == ''
+      - not result.datasource.withCredentials
+      - result.msg == 'Datasource datasource-sentry updated'
+
+- name: Delete sentry datasource
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-sentry
+    state: absent
+
+- ansible.builtin.assert:
+    that:
+      - result.changed
+
+- name: Delete sentry datasource (idempotency)
+  register: result
+  community.grafana.grafana_datasource:
+    name: datasource-sentry
+    state: absent
+
+- ansible.builtin.assert:
+    that:
+      - not result.changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds support for defining a datasource from the [grafana-sentry-datasource plugin](https://grafana.com/grafana/plugins/grafana-sentry-datasource/).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
grafana_datasource

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Note -- I haven't yet been able to run the integration tests successfully to validate that the ones I have added pass.

It looks like I have missed a step when trying to set them up. Would appreciate any guidance on getting these working! I tried standing up a docker image similar to what is done in the github action worker with `docker run --rm -d --name=grafana -p 3000:3000 grafana/grafana:12.0.2`, but that didn't seem to help. 
```TASK [../../grafana_contact_point : Create alertmanager contact point] *********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: GrafanaAPIException: Unable to switch to organization '1': {'url': 'http://grafana:3000/api/user/using/1', 'status': -1, 'msg': 'Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>'}
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1767842029.9236333-155-268721974960901/AnsiballZ_grafana_contact_point.py\", line 121, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1767842029.9236333-155-268721974960901/AnsiballZ_grafana_contact_point.py\", line 113, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1767842029.9236333-155-268721974960901/AnsiballZ_grafana_contact_point.py\", line 61, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.grafana.plugins.modules.grafana_contact_point', init_globals=dict(_module_fqn='ansible_collections.community.grafana.plugins.modules.grafana_contact_point', _modlib_path=modlib_path),\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_community.grafana.grafana_contact_point_payload_d8xew622/ansible_community.grafana.grafana_contact_point_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_contact_point.py\", line 1355, in <module>\n  File \"/tmp/ansible_community.grafana.grafana_contact_point_payload_d8xew622/ansible_community.grafana.grafana_contact_point_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_contact_point.py\", line 1348, in main\n  File \"/tmp/ansible_community.grafana.grafana_contact_point_payload_d8xew622/ansible_community.grafana.grafana_contact_point_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_contact_point.py\", line 975, in __init__\n  File \"/tmp/ansible_community.grafana.grafana_contact_point_payload_d8xew622/ansible_community.grafana.grafana_contact_point_payload.zip/ansible_collections/community/grafana/plugins/modules/grafana_contact_point.py\", line 1016, in grafana_switch_organisation\nGrafanaAPIException: Unable to switch to organization '1': {'url': 'http://grafana:3000/api/user/using/1', 'status': -1, 'msg': 'Request failed: <urlopen error [Errno -3] Temporary failure in name resolution>'}\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

