### PR TITLE
Replace ansible.module_utils.six with Python stdlib equivalents

### DIFF
--- a/changelogs/fragments/remove-module-utils-six.yml
+++ b/changelogs/fragments/remove-module-utils-six.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Replace the deprecated ``ansible.module_utils.six`` compatibility shims with
+    their Python standard library equivalents. ``ansible.module_utils.six`` is
+    deprecated in ansible-core 2.21 and is scheduled for removal in 2.24.

--- a/plugins/lookup/grafana_dashboard.py
+++ b/plugins/lookup/grafana_dashboard.py
@@ -74,11 +74,11 @@ EXAMPLES = """
 
 import json
 import os
+from urllib.error import HTTPError
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.urls import basic_auth_header, open_url, SSLValidationError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.utils.display import Display
 
 display = Display()

--- a/plugins/modules/grafana_dashboard.py
+++ b/plugins/modules/grafana_dashboard.py
@@ -149,9 +149,9 @@ uid:
 """
 
 import json
+from urllib.parse import urlencode
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
 from ansible_collections.community.grafana.plugins.module_utils.base import (

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -540,9 +540,9 @@ datasource:
 """
 
 import json
+from urllib.parse import quote
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
 

--- a/plugins/modules/grafana_datasource.py
+++ b/plugins/modules/grafana_datasource.py
@@ -546,7 +546,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
 
-
 ES_VERSION_MAPPING = {
     "7.7+": "7.7.0",
     "7.10+": "7.10.0",

--- a/plugins/modules/grafana_organization.py
+++ b/plugins/modules/grafana_organization.py
@@ -97,11 +97,11 @@ org:
 """
 
 import json
+from urllib.parse import quote
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 

--- a/plugins/modules/grafana_team.py
+++ b/plugins/modules/grafana_team.py
@@ -203,12 +203,12 @@ team:
 """
 
 import json
+from urllib.parse import quote
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible.module_utils._text import to_text
 from ansible_collections.community.grafana.plugins.module_utils import base
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 

--- a/plugins/modules/grafana_user.py
+++ b/plugins/modules/grafana_user.py
@@ -155,11 +155,11 @@ user:
 """
 
 import json
+from urllib.parse import quote
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, basic_auth_header
 from ansible_collections.community.grafana.plugins.module_utils import base
-from ansible.module_utils.six.moves.urllib.parse import quote
 
 __metaclass__ = type
 


### PR DESCRIPTION
##### SUMMARY

`ansible.module_utils.six` is deprecated in ansible-core 2.21 and scheduled for removal in 2.24. All six uses in this collection are urllib re-exports, replaced with their stdlib originals:

```python
-from ansible.module_utils.six.moves.urllib.parse import quote, urlencode
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.parse import quote, urlencode
+from urllib.error import HTTPError
```

On Python 3 `six.moves.urllib.parse` and `six.moves.urllib.error` are lazy aliases that resolve to the identical stdlib objects, so every call site and `except` clause behaves the same. A changelog fragment is included.

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

grafana_dashboard, grafana_datasource, grafana_organization, grafana_team, grafana_user
